### PR TITLE
Bug fix: Forwarding the change event from the input element

### DIFF
--- a/packages/switch/mwc-switch.js
+++ b/packages/switch/mwc-switch.js
@@ -49,6 +49,11 @@ export class Switch extends LitElement {
     super.ready();
     await afterNextRender;
     this._input = this._root.querySelector('input');
+    //bug fix: forwarding the change event and setting the check property
+    this._input.addEventListener('change', event => {
+      this.checked = event.target.checked;
+      this.dispatchEvent(new CustomEvent('change', event));
+    });
   }
 
   click() {


### PR DESCRIPTION
Hi this is my first pull request. So I made one little change to the switch element to improve it.
Sorry my commit message is a little bit broken. Anyhow I think the change event got lost because of some shadow DOM things.  

**commit message again:** 
> "bug fix: forwarding the change event from the input element and setting the check property value"
