### PR TITLE
Fix dependency references and tests.

### DIFF
--- a/packages/all.js
+++ b/packages/all.js
@@ -15,7 +15,7 @@
  */
 
 export {Button} from '@material/mwc-button/mwc-button.js';
-export {Fab} from '@material/mwc-button/mwc-fab.js';
+export {Fab} from '@material/mwc-fab/mwc-fab.js';
 export {Checkbox} from '@material/mwc-checkbox/mwc-checkbox.js';
 export {Chip} from '@material/mwc-chips/mwc-chip.js';
 export {ChipSet} from '@material/mwc-chips/mwc-chip-set.js';
@@ -28,7 +28,6 @@ export {ListItem} from '@material/mwc-list/mwc-list-item.js';
 export {Menu} from '@material/mwc-menu/mwc-menu.js';
 export {Radio} from '@material/mwc-radio/mwc-radio.js';
 export {Ripple} from '@material/mwc-ripple/mwc-ripple.js';
-export {RippleSurface} from '@material/mwc-ripple/mwc-ripple-surface.js';
 export {Select} from '@material/mwc-select/mwc-select.js';
 export {Slider} from '@material/mwc-slider/mwc-slider.js';
 export {Snackbar} from '@material/mwc-snackbar/mwc-snackbar.js';

--- a/test/unit/mwc-button.test.js
+++ b/test/unit/mwc-button.test.js
@@ -16,7 +16,7 @@
 
 import {assert} from 'chai';
 import {Button} from '@material/mwc-button';
-import {Fab} from '@material/mwc-button/mwc-fab.js';
+import {Fab} from '@material/mwc-fab';
 
 let element;
 

--- a/test/unit/mwc-checkbox.test.js
+++ b/test/unit/mwc-checkbox.test.js
@@ -41,11 +41,12 @@ test('element._formElement returns the native checkbox element', () => {
   assert.equal(element._formElement.localName, 'input');
 });
 
-test('element._component returns the mdc checkbox component', () => {
+test('element._component returns the mdc checkbox component', async () => {
+  await element.componentReady();
   assert.instanceOf(element._component, MDCCheckbox);
 });
 
-test('get/set checked updates the checked property on the native checkbox element', () => {
+test('get/set checked updates the checked property on the native checkbox element', async () => {
   element.checked = true;
   await element.componentReady();
   assert.equal(element._component.checked, true);
@@ -56,7 +57,7 @@ test('get/set checked updates the checked property on the native checkbox elemen
   assert.equal(element._formElement.checked, false);
 });
 
-test('get/set indeterminate updates the indeterminate property on the native checkbox element', () => {
+test('get/set indeterminate updates the indeterminate property on the native checkbox element', async () => {
   element.indeterminate = true;
   await element.componentReady();
   assert.equal(element._formElement.indeterminate, true);
@@ -65,7 +66,7 @@ test('get/set indeterminate updates the indeterminate property on the native che
   assert.equal(element._formElement.indeterminate, false);
 });
 
-test('get/set disabled updates the disabled property on the native checkbox element', () => {
+test('get/set disabled updates the disabled property on the native checkbox element', async () => {
   element.disabled = true;
   await element.componentReady();
   assert.equal(element._formElement.disabled, true);
@@ -74,7 +75,7 @@ test('get/set disabled updates the disabled property on the native checkbox elem
   assert.equal(element._formElement.disabled, false);
 });
 
-test('get/set value updates the value of the native checkbox element', () => {
+test('get/set value updates the value of the native checkbox element', async () => {
   let value = 'new value';
   element.value = value;
   await element.componentReady();

--- a/test/unit/mwc-ripple.test.js
+++ b/test/unit/mwc-ripple.test.js
@@ -16,7 +16,6 @@
 
 import {assert} from 'chai';
 import {Ripple} from '@material/mwc-ripple';
-import {RippleSurface} from '@material/mwc-ripple/mwc-ripple-surface.js';
 
 let element;
 
@@ -33,19 +32,4 @@ afterEach(() => {
 
 test('initializes as an mwc-ripple', () => {
   assert.instanceOf(element, Ripple);
-});
-
-suite('mwc-ripple-surface');
-
-beforeEach(() => {
-  element = document.createElement('mwc-ripple-surface');
-  document.body.appendChild(element);
-});
-
-afterEach(() => {
-  document.body.removeChild(element);
-});
-
-test('initializes as an mwc-ripple-surface', () => {
-  assert.instanceOf(element, RippleSurface);
 });


### PR DESCRIPTION
- `mwc-fab` is now in its own package.
- `mwc-ripple-surface` doesn't seem to exist as a separate component anymore.
- Adds `async` to a few test functions that were using `await`.

There are still some left over uncaught errors that happen when running the tests that I'm still looking into. They don't cause the tests to fail though, so they must be async.