### PR TITLE
[Textfield] add name attribute and reflect input value to element attribute

### DIFF
--- a/packages/textfield/mwc-textfield.js
+++ b/packages/textfield/mwc-textfield.js
@@ -100,7 +100,7 @@ export class Textfield extends ComponentElement {
   }
 
   _renderInput({name, value, required, type, placeHolder, label}) {
-    return html`<input on-change="${(e) => this._updateValue(e)}" type="text" name$="${name}" type$="${type}" placeholder$="${placeHolder}" required?="${required}" class$="mdc-text-field__input ${value ? 'mdc-text-field--upgraded' : ''}" id="text-field" value="${value}" aria-label$="${label}">`;
+    return html`<input on-input="${(e) => this._updateValue(e)}" type="text" name$="${name}" type$="${type}" placeholder$="${placeHolder}" required?="${required}" class$="mdc-text-field__input ${value ? 'mdc-text-field--upgraded' : ''}" id="text-field" value="${value}" aria-label$="${label}">`;
   }
 
   ready() {

--- a/packages/textfield/mwc-textfield.js
+++ b/packages/textfield/mwc-textfield.js
@@ -36,6 +36,7 @@ export class Textfield extends ComponentElement {
 
   static get properties() {
     return {
+      name: String,
       value: String,
       label: String,
       icon: String,
@@ -55,6 +56,7 @@ export class Textfield extends ComponentElement {
     super();
     this._asyncComponent = true;
     this.required = false;
+    this.name = '';
     this.value = '';
     this.label = '';
     this.icon = '';
@@ -73,7 +75,7 @@ export class Textfield extends ComponentElement {
   }
 
   // TODO(sorvell) #css: styling for fullwidth
-  _render({value, label, box, outlined, disabled, icon, iconTrailing, fullWidth, required, placeHolder, helperText, type}) {
+  _render({name, value, label, box, outlined, disabled, icon, iconTrailing, fullWidth, required, placeHolder, helperText, type}) {
     const hostClasses = c$({
       'mdc-text-field--with-leading-icon': icon && !iconTrailing,
       'mdc-text-field--with-trailing-icon': icon && iconTrailing,
@@ -86,7 +88,7 @@ export class Textfield extends ComponentElement {
       ${this._renderStyle()}
       <div class$="mdc-text-field mdc-text-field--upgraded ${hostClasses}">
         ${!fullWidth && icon ? html`<i class="material-icons mdc-text-field__icon" tabindex="0">${icon}</i>` : ''}
-        ${this._renderInput({value, required, type, placeHolder, label})}
+        ${this._renderInput({name, value, required, type, placeHolder, label})}
         ${!fullWidth && label ? html`<label class$="mdc-floating-label ${value ? 'mdc-floating-label--float-above' : ''}" for="text-field">${label}</label>` : ''}
         ${!fullWidth && outlined ? html`<div class="mdc-notched-outline">
             <svg><path class="mdc-notched-outline__path"/></svg>
@@ -97,8 +99,8 @@ export class Textfield extends ComponentElement {
       ${helperText ? html`<p class="mdc-text-field-helper-text" aria-hidden="true">${helperText}</p>` : ''}`;
   }
 
-  _renderInput({value, required, type, placeHolder, label}) {
-    return html`<input type="text" type$="${type}" placeholder$="${placeHolder}" required?="${required}" class$="mdc-text-field__input ${value ? 'mdc-text-field--upgraded' : ''}" id="text-field" value="${value}" aria-label$="${label}">`;
+  _renderInput({name, value, required, type, placeHolder, label}) {
+    return html`<input on-change="${(e) => this._updateValue(e)}" type="text" name$="${name}" type$="${type}" placeholder$="${placeHolder}" required?="${required}" class$="mdc-text-field__input ${value ? 'mdc-text-field--upgraded' : ''}" id="text-field" value="${value}" aria-label$="${label}">`;
   }
 
   ready() {
@@ -122,6 +124,10 @@ export class Textfield extends ComponentElement {
 
   focus() {
     this._input.focus();
+  }
+  
+  _updateValue(e) {
+    this.value = e.target.value; 
   }
 }
 

--- a/packages/textfield/mwc-textfield.js
+++ b/packages/textfield/mwc-textfield.js
@@ -100,7 +100,7 @@ export class Textfield extends ComponentElement {
   }
 
   _renderInput({name, value, required, type, placeHolder, label}) {
-    return html`<input on-input="${(e) => this._updateValue(e)}" type="text" name$="${name}" type$="${type}" placeholder$="${placeHolder}" required?="${required}" class$="mdc-text-field__input ${value ? 'mdc-text-field--upgraded' : ''}" id="text-field" value="${value}" aria-label$="${label}">`;
+    return html `<input on-change="${(e) => this._onChange(e)}" on-input="${(e) => this._updateValue(e)}" type="text" name$="${name}" type$="${type}" placeholder$="${placeHolder}" required?="${required}" class$="mdc-text-field__input ${value ? 'mdc-text-field--upgraded' : ''}" id="text-field" value="${value}" aria-label$="${label}">`;
   }
 
   ready() {
@@ -127,8 +127,23 @@ export class Textfield extends ComponentElement {
   }
   
   _updateValue(e) {
-    this.value = e.target.value; 
+    this.value = e.target.value;
+    this.dispatchEvent(new CustomEvent("value-changed"));
   }
+
+  _onChange(e) {
+    if (this.shadowRoot) {
+      this.dispatchEvent(
+        new CustomEvent(
+          e.type, {
+            bubbles: e.bubbles,
+            cancelable: e.cancelable
+          }
+        )
+      );
+    }
+  }
+
 }
 
 customElements.define('mwc-textfield', Textfield);


### PR DESCRIPTION
Hi Liters,
a PR to improve text-field component, and get it work with "iron-form": 
- add the name attribute to the embedded input.
- reflect input value to element value attribute.
- fire value-changed event.
- fire change event when shadowRoot

Regards,