### PR TITLE
Checkbox and iron-form

### DIFF
--- a/packages/checkbox/mwc-checkbox.js
+++ b/packages/checkbox/mwc-checkbox.js
@@ -35,6 +35,7 @@ export class Checkbox extends FormableComponentElement {
       indeterminate: Boolean,
       disabled: Boolean,
       value: String,
+      name: String
     };
   }
 
@@ -51,6 +52,7 @@ export class Checkbox extends FormableComponentElement {
     this.indeterminate = false;
     this.disabled = false;
     this.value = '';
+    this.name = '';
     this._boundInputChangeHandler = this._inputChangeHandler.bind(this);
   }
 
@@ -65,7 +67,7 @@ export class Checkbox extends FormableComponentElement {
       <div class="mdc-checkbox">
         <input type="checkbox"
           class="mdc-checkbox__native-control"
-          checked="${checked}" value="${value}"
+          name$="${name}" checked="${checked}" value="${value}"
           on-change="${this._boundInputChangeHandler}">
         <div class="mdc-checkbox__background">
           <svg class="mdc-checkbox__checkmark"

--- a/packages/checkbox/mwc-checkbox.js
+++ b/packages/checkbox/mwc-checkbox.js
@@ -51,9 +51,10 @@ export class Checkbox extends FormableComponentElement {
     this.checked = false;
     this.indeterminate = false;
     this.disabled = false;
-    this.value = '';
+    this.value = 'on';
     this.name = '';
     this._boundInputChangeHandler = this._inputChangeHandler.bind(this);
+    this._hasIronCheckedElementBehavior = true;
   }
 
   // TODO(sorvell) #css: add outline none to avoid focus decoration


### PR DESCRIPTION
Hi,
this is more a proposal than a fix PR.
The idea is to get this element works with iron-form so i had the **name** attribute and also a property : **_hasIronCheckedElementBehavior** to allow iron-form to handle checkbox checked value.

I'm not sure this is a good way to handle MWC form, may be a transitional way with iron-form until a MWC alternative exists ?

