### PR TITLE
Extra tests for button, FAB. Add `label` property to FAB.

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -57,6 +57,7 @@ limitations under the License.
       <mwc-button label="Normal"></mwc-button>
       <mwc-button class="light" raised label="raised"></mwc-button>
       <mwc-button unelevated label="unelevated"></mwc-button>
+      <mwc-button outlined label="outlined"></mwc-button>
       <mwc-button class="pink" dense label="dense"></mwc-button>
       <mwc-button class="pink wide" raised label="wide"></mwc-button>
       <mwc-button disabled label="disabled"></mwc-button>
@@ -68,6 +69,7 @@ limitations under the License.
       <mwc-button label="Normal" icon="explore"></mwc-button>
       <mwc-button class="light" raised label="raised" icon="code"></mwc-button>
       <mwc-button unelevated label="unelevated" icon="check"></mwc-button>
+      <mwc-button outlined label="outlined" icon="alarm"></mwc-button>
       <mwc-button class="pink" dense label="dense" icon="feedback"></mwc-button>
       <mwc-button class="pink wide" raised label="wide" icon="code"></mwc-button>
       <mwc-button disabled label="disabled" icon="fingerprint"></mwc-button>

--- a/demos/fab.html
+++ b/demos/fab.html
@@ -59,9 +59,9 @@ limitations under the License.
   <main>
 
     <div class="demo-fab-group demo-group-spaced">
-      <mwc-fab icon="explore"></mwc-fab>
-      <mwc-fab class="light" icon="code"></mwc-fab>
-      <mwc-fab icon="feedback"></mwc-fab>
+      <mwc-fab icon="explore" label="Explore the world. (This is an example label.)"></mwc-fab>
+      <mwc-fab class="light" icon="code" label="Show me the code. (This is an example label.)"></mwc-fab>
+      <mwc-fab icon="feedback" label="Provide feedback. (This is an example label.)"></mwc-fab>
       <mwc-fab class="pink" icon="gavel" mini></mwc-fab>
       <mwc-fab icon="fingerprint" disabled></mwc-fab>
     </div>

--- a/packages/button/mwc-button.js
+++ b/packages/button/mwc-button.js
@@ -27,7 +27,6 @@ export class Button extends LitElement {
       unelevated: Boolean,
       stroked: Boolean,
       dense: Boolean,
-      compact: Boolean,
       disabled: Boolean,
       icon: String,
       label: String,
@@ -40,7 +39,6 @@ export class Button extends LitElement {
     this.unelevated = false;
     this.stroked = false;
     this.dense = false;
-    this.compact = false;
     this.disabled = false;
     this.icon = '';
     this.label = '';
@@ -60,13 +58,12 @@ export class Button extends LitElement {
     return style;
   }
 
-  _render({raised, unelevated, stroked, dense, compact, disabled, icon, label}) {
+  _render({raised, unelevated, stroked, dense, disabled, icon, label}) {
     const hostClasses = c$({
       'mdc-button--raised': raised,
       'mdc-button--unelevated': unelevated,
       'mdc-button--stroked': stroked,
       'mdc-button--dense': dense,
-      'mdc-button--compact': compact,
     });
     return html`
       ${this._renderStyle()}

--- a/packages/button/mwc-button.js
+++ b/packages/button/mwc-button.js
@@ -25,7 +25,7 @@ export class Button extends LitElement {
     return {
       raised: Boolean,
       unelevated: Boolean,
-      stroked: Boolean,
+      outlined: Boolean,
       dense: Boolean,
       disabled: Boolean,
       icon: String,
@@ -37,7 +37,7 @@ export class Button extends LitElement {
     super();
     this.raised = false;
     this.unelevated = false;
-    this.stroked = false;
+    this.outlined = false;
     this.dense = false;
     this.disabled = false;
     this.icon = '';
@@ -58,11 +58,11 @@ export class Button extends LitElement {
     return style;
   }
 
-  _render({raised, unelevated, stroked, dense, disabled, icon, label}) {
+  _render({raised, unelevated, outlined, dense, disabled, icon, label}) {
     const hostClasses = c$({
       'mdc-button--raised': raised,
       'mdc-button--unelevated': unelevated,
-      'mdc-button--stroked': stroked,
+      'mdc-button--outlined': outlined,
       'mdc-button--dense': dense,
     });
     return html`

--- a/packages/fab/mwc-fab.js
+++ b/packages/fab/mwc-fab.js
@@ -36,7 +36,7 @@ export class Fab extends LitElement {
     this.icon = '';
     this.mini = false;
     this.exited = false;
-    this.label = undefined;
+    this.label = '';
   }
 
   _createRoot() {

--- a/packages/fab/mwc-fab.js
+++ b/packages/fab/mwc-fab.js
@@ -27,6 +27,7 @@ export class Fab extends LitElement {
       exited: Boolean,
       disabled: Boolean,
       icon: String,
+      label: String,
     };
   }
 
@@ -35,6 +36,7 @@ export class Fab extends LitElement {
     this.icon = '';
     this.mini = false;
     this.exited = false;
+    this.label = undefined;
   }
 
   _createRoot() {
@@ -51,14 +53,14 @@ export class Fab extends LitElement {
     return style;
   }
 
-  _render({icon, mini, exited, disabled}) {
+  _render({icon, mini, exited, disabled, label}) {
     const hostClasses = c$({
       'mdc-fab--mini': mini,
       'mdc-fab--exited': exited,
     });
     return html`
       ${this._renderStyle()}
-      <button class$="mdc-fab ${hostClasses}" disabled?="${disabled}" aria-label$="${icon}">
+      <button class$="mdc-fab ${hostClasses}" disabled?="${disabled}" aria-label$="${label || icon}">
         ${icon ? html`<span class="material-icons mdc-fab__icon">${icon}</span>` : ''}
       </button>`;
   }

--- a/test/unit/mwc-button.test.js
+++ b/test/unit/mwc-button.test.js
@@ -47,6 +47,24 @@ test('get/set disabled updates the disabled property on the native button elemen
   assert.equal(button.hasAttribute('disabled'), false);
 });
 
+test('setting `icon` adds an icon to the button', async () => {
+  const ICON_SELECTOR = '.mdc-button__icon';
+
+  await afterNextRender();
+  let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
+  assert.equal(icon, null);
+
+  element.icon = 'check';
+  await afterNextRender();
+  icon = element.shadowRoot.querySelector(ICON_SELECTOR);
+  assert.instanceOf(icon, Element);
+
+  element.icon = undefined;
+  await afterNextRender();
+  icon = element.shadowRoot.querySelector(ICON_SELECTOR);
+  assert.equal(icon, null);
+});
+
 suite('mwc-fab');
 
 beforeEach(() => {
@@ -71,4 +89,22 @@ test('get/set disabled updates the disabled property on the native button elemen
   element.disabled = false;
   await afterNextRender();
   assert.equal(button.hasAttribute('disabled'), false);
+});
+
+test('setting `icon` adds an icon to the fab', async () => {
+  const ICON_SELECTOR = '.mdc-fab__icon';
+
+  await afterNextRender();
+  let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
+  assert.equal(icon, null);
+
+  element.icon = 'check';
+  await afterNextRender();
+  icon = element.shadowRoot.querySelector(ICON_SELECTOR);
+  assert.instanceOf(icon, Element);
+
+  element.icon = undefined;
+  await afterNextRender();
+  icon = element.shadowRoot.querySelector(ICON_SELECTOR);
+  assert.equal(icon, null);
 });

--- a/test/unit/mwc-button.test.js
+++ b/test/unit/mwc-button.test.js
@@ -18,6 +18,8 @@ import {assert} from 'chai';
 import {Button} from '@material/mwc-button';
 import {afterNextRender} from '@material/mwc-base/utils.js';
 
+const ICON_SELECTOR = '.mdc-button__icon';
+
 let element;
 
 suite('mwc-button');
@@ -47,8 +49,6 @@ test('get/set disabled updates the disabled property on the native button elemen
 });
 
 test('setting `icon` adds an icon to the button', async () => {
-  const ICON_SELECTOR = '.mdc-button__icon';
-
   await afterNextRender();
   let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);

--- a/test/unit/mwc-button.test.js
+++ b/test/unit/mwc-button.test.js
@@ -17,6 +17,7 @@
 import {assert} from 'chai';
 import {Button} from '@material/mwc-button';
 import {Fab} from '@material/mwc-fab';
+import {afterNextRender} from '@material/mwc-base/utils.js';
 
 let element;
 
@@ -35,6 +36,17 @@ test('initializes as an mwc-button', () => {
   assert.instanceOf(element, Button);
 });
 
+test('get/set disabled updates the disabled property on the native button element', async () => {
+  element.disabled = true;
+  await afterNextRender();
+  const button = element.shadowRoot.querySelector('button');
+  assert.equal(button.hasAttribute('disabled'), true);
+
+  element.disabled = false;
+  await afterNextRender();
+  assert.equal(button.hasAttribute('disabled'), false);
+});
+
 suite('mwc-fab');
 
 beforeEach(() => {
@@ -48,4 +60,15 @@ afterEach(() => {
 
 test('initializes as an mwc-fab', () => {
   assert.instanceOf(element, Fab);
+});
+
+test('get/set disabled updates the disabled property on the native button element', async () => {
+  element.disabled = true;
+  await afterNextRender();
+  const button = element.shadowRoot.querySelector('button');
+  assert.equal(button.hasAttribute('disabled'), true);
+
+  element.disabled = false;
+  await afterNextRender();
+  assert.equal(button.hasAttribute('disabled'), false);
 });

--- a/test/unit/mwc-button.test.js
+++ b/test/unit/mwc-button.test.js
@@ -108,3 +108,31 @@ test('setting `icon` adds an icon to the fab', async () => {
   icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);
 });
+
+test('setting `icon` sets `aria-label` of the button', async () => {
+  const ICON_SELECTOR = '.mdc-fab__icon';
+
+  element.icon = 'check';
+  await afterNextRender();
+  const button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'check');
+});
+
+test('setting `label` sets `aria-label` of the button, overriding `icon`', async () => {
+  const ICON_SELECTOR = '.mdc-fab__icon';
+
+  element.icon = 'check';
+  await afterNextRender();
+  button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'check');
+
+  element.label = 'label text';
+  await afterNextRender();
+  let button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'label text');
+
+  element.label = undefined;
+  await afterNextRender();
+  button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'check');
+});

--- a/test/unit/mwc-button.test.js
+++ b/test/unit/mwc-button.test.js
@@ -16,7 +16,6 @@
 
 import {assert} from 'chai';
 import {Button} from '@material/mwc-button';
-import {afterNextRender} from '@material/mwc-base/utils.js';
 
 const ICON_SELECTOR = '.mdc-button__icon';
 
@@ -39,27 +38,27 @@ test('initializes as an mwc-button', () => {
 
 test('get/set disabled updates the disabled property on the native button element', async () => {
   element.disabled = true;
-  await afterNextRender();
+  await element.renderComplete;
   const button = element.shadowRoot.querySelector('button');
   assert.equal(button.hasAttribute('disabled'), true);
 
   element.disabled = false;
-  await afterNextRender();
+  await element.renderComplete;
   assert.equal(button.hasAttribute('disabled'), false);
 });
 
 test('setting `icon` adds an icon to the button', async () => {
-  await afterNextRender();
+  await element.renderComplete;
   let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);
 
   element.icon = 'check';
-  await afterNextRender();
+  await element.renderComplete;
   icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.instanceOf(icon, Element);
 
   element.icon = undefined;
-  await afterNextRender();
+  await element.renderComplete;
   icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);
 });

--- a/test/unit/mwc-fab.test.js
+++ b/test/unit/mwc-fab.test.js
@@ -16,7 +16,6 @@
 
 import {assert} from 'chai';
 import {Fab} from '@material/mwc-fab';
-import {afterNextRender} from '@material/mwc-base/utils.js';
 
 const ICON_SELECTOR = '.mdc-fab__icon';
 
@@ -39,51 +38,51 @@ test('initializes as an mwc-fab', () => {
 
 test('get/set disabled updates the disabled property on the native button element', async () => {
   element.disabled = true;
-  await afterNextRender();
+  await element.renderComplete;
   const button = element.shadowRoot.querySelector('button');
   assert.equal(button.hasAttribute('disabled'), true);
 
   element.disabled = false;
-  await afterNextRender();
+  await element.renderComplete;
   assert.equal(button.hasAttribute('disabled'), false);
 });
 
 test('setting `icon` adds an icon to the fab', async () => {
-  await afterNextRender();
+  await element.renderComplete;
   let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);
 
   element.icon = 'check';
-  await afterNextRender();
+  await element.renderComplete;
   icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.instanceOf(icon, Element);
 
   element.icon = undefined;
-  await afterNextRender();
+  await element.renderComplete;
   icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);
 });
 
 test('setting `icon` sets `aria-label` of the button', async () => {
   element.icon = 'check';
-  await afterNextRender();
+  await element.renderComplete;
   const button = element.shadowRoot.querySelector('button');
   assert.equal(button.getAttribute('aria-label'), 'check');
 });
 
 test('setting `label` sets `aria-label` of the button, overriding `icon`', async () => {
   element.icon = 'check';
-  await afterNextRender();
+  await element.renderComplete;
   button = element.shadowRoot.querySelector('button');
   assert.equal(button.getAttribute('aria-label'), 'check');
 
   element.label = 'label text';
-  await afterNextRender();
+  await element.renderComplete;
   let button = element.shadowRoot.querySelector('button');
   assert.equal(button.getAttribute('aria-label'), 'label text');
 
   element.label = undefined;
-  await afterNextRender();
+  await element.renderComplete;
   button = element.shadowRoot.querySelector('button');
   assert.equal(button.getAttribute('aria-label'), 'check');
 });

--- a/test/unit/mwc-fab.test.js
+++ b/test/unit/mwc-fab.test.js
@@ -18,6 +18,8 @@ import {assert} from 'chai';
 import {Fab} from '@material/mwc-fab';
 import {afterNextRender} from '@material/mwc-base/utils.js';
 
+const ICON_SELECTOR = '.mdc-fab__icon';
+
 let element;
 
 suite('mwc-fab');
@@ -47,8 +49,6 @@ test('get/set disabled updates the disabled property on the native button elemen
 });
 
 test('setting `icon` adds an icon to the fab', async () => {
-  const ICON_SELECTOR = '.mdc-fab__icon';
-
   await afterNextRender();
   let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);
@@ -65,8 +65,6 @@ test('setting `icon` adds an icon to the fab', async () => {
 });
 
 test('setting `icon` sets `aria-label` of the button', async () => {
-  const ICON_SELECTOR = '.mdc-fab__icon';
-
   element.icon = 'check';
   await afterNextRender();
   const button = element.shadowRoot.querySelector('button');
@@ -74,8 +72,6 @@ test('setting `icon` sets `aria-label` of the button', async () => {
 });
 
 test('setting `label` sets `aria-label` of the button, overriding `icon`', async () => {
-  const ICON_SELECTOR = '.mdc-fab__icon';
-
   element.icon = 'check';
   await afterNextRender();
   button = element.shadowRoot.querySelector('button');

--- a/test/unit/mwc-fab.test.js
+++ b/test/unit/mwc-fab.test.js
@@ -15,15 +15,15 @@
  */
 
 import {assert} from 'chai';
-import {Button} from '@material/mwc-button';
+import {Fab} from '@material/mwc-fab';
 import {afterNextRender} from '@material/mwc-base/utils.js';
 
 let element;
 
-suite('mwc-button');
+suite('mwc-fab');
 
 beforeEach(() => {
-  element = document.createElement('mwc-button');
+  element = document.createElement('mwc-fab');
   document.body.appendChild(element);
 });
 
@@ -31,8 +31,8 @@ afterEach(() => {
   document.body.removeChild(element);
 });
 
-test('initializes as an mwc-button', () => {
-  assert.instanceOf(element, Button);
+test('initializes as an mwc-fab', () => {
+  assert.instanceOf(element, Fab);
 });
 
 test('get/set disabled updates the disabled property on the native button element', async () => {
@@ -46,8 +46,8 @@ test('get/set disabled updates the disabled property on the native button elemen
   assert.equal(button.hasAttribute('disabled'), false);
 });
 
-test('setting `icon` adds an icon to the button', async () => {
-  const ICON_SELECTOR = '.mdc-button__icon';
+test('setting `icon` adds an icon to the fab', async () => {
+  const ICON_SELECTOR = '.mdc-fab__icon';
 
   await afterNextRender();
   let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
@@ -62,4 +62,32 @@ test('setting `icon` adds an icon to the button', async () => {
   await afterNextRender();
   icon = element.shadowRoot.querySelector(ICON_SELECTOR);
   assert.equal(icon, null);
+});
+
+test('setting `icon` sets `aria-label` of the button', async () => {
+  const ICON_SELECTOR = '.mdc-fab__icon';
+
+  element.icon = 'check';
+  await afterNextRender();
+  const button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'check');
+});
+
+test('setting `label` sets `aria-label` of the button, overriding `icon`', async () => {
+  const ICON_SELECTOR = '.mdc-fab__icon';
+
+  element.icon = 'check';
+  await afterNextRender();
+  button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'check');
+
+  element.label = 'label text';
+  await afterNextRender();
+  let button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'label text');
+
+  element.label = undefined;
+  await afterNextRender();
+  button = element.shadowRoot.querySelector('button');
+  assert.equal(button.getAttribute('aria-label'), 'check');
 });


### PR DESCRIPTION
- Are the tests too brittle by they way they look into the internals to find elements?
- I added `label` as a property of fab because users will want to label the button in FABs with text that's more descriptive than just the icon name.
- Tests for the FAB are split into a different file.