### PR TITLE
Remove broken import

### DIFF
--- a/packages/button/mwc-button.js
+++ b/packages/button/mwc-button.js
@@ -18,7 +18,7 @@ import {LitElement, html, classString as c$} from '@polymer/lit-element/lit-elem
 import {style} from './mwc-button-css.js';
 import {MDCWCRipple} from '@material/mwc-ripple/mwc-ripple.js';
 import {afterNextRender} from '@material/mwc-base/utils.js';
-import '@material/mwc-icon/mwc-icon-font.js';
+//import '@material/mwc-icon/mwc-icon-font.js';
 
 export class Button extends LitElement {
   static get properties() {


### PR DESCRIPTION
This is a little overkill but I don't know exactly what would work in rollup & webpack etc?
Avoids (!) Unresolved dependencies
https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency
@material/mwc-icon/mwc-icon-font.js (imported by node_modules/@material/mwc-button/mwc-button.js)