### PR TITLE
add textarea component

### DIFF
--- a/demos/textfield.html
+++ b/demos/textfield.html
@@ -21,6 +21,7 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script  src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   <script type="module" src="../node_modules/@material/mwc-textfield/mwc-textfield.js"></script>
+  <script type="module" src="../node_modules/@material/mwc-textarea/mwc-textarea.js"></script>
   <script type="module" src="../node_modules/@material/mwc-icon/mwc-icon.js"></script>
   <link rel="stylesheet" href="demo-component.css">
 </head>
@@ -92,12 +93,29 @@ limitations under the License.
 
     </div>
 
-    <h4>fullWidth</h4>
+    <h4>Textarea</h4>
+    
+    <div class="demo-group-spaced">
+        <mwc-textarea label="Standard"></mwc-textarea>
+        <mwc-textarea dense label="Dense" ></mwc-textarea>
+        <mwc-textarea label="With helper text" helperText="Helper text"></mwc-textarea>
+    
+    </div>
+
+    <h4>Textfield fullWidth</h4>
+
 
     <mwc-textfield fullwidth></mwc-textfield>
     <mwc-textfield fullwidth placeholder="Say something.." ></mwc-textfield>
     <mwc-textfield fullwidth label="Say something..."></mwc-textfield>
     <mwc-textfield fullwidth label="Say something..." value="hi"></mwc-textfield>
+
+
+    <h4>Full Width Textarea</h4>
+
+    <mwc-textarea fullwidth label="Standard" ></mwc-textarea>
+    <mwc-textarea fullwidth dense label="Dense" ></mwc-textarea>
+    <mwc-textarea fullwidth label="With helper text" helperText="Helper text"></mwc-textarea>
 
   </main>
 

--- a/packages/textarea/mwc-textarea.js
+++ b/packages/textarea/mwc-textarea.js
@@ -1,0 +1,78 @@
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {ComponentElement, html} from '@material/mwc-base/component-element.js';
+import {classString as c$} from '@polymer/lit-element/lit-element.js';
+import {Textfield} from '@material/mwc-textfield';
+
+export class Textarea extends Textfield {
+
+  static get properties() {
+    return {
+      name: String,
+      value: String,
+      label: String,
+      disabled: Boolean,
+      dense: Boolean,
+      fullWidth: Boolean,
+      required: Boolean,
+      helperText: '',
+      placeHolder: '',
+      rows: String,
+      cols: String
+    };
+  }
+
+  constructor() {
+    super();
+    this.required = false;
+    this.name = '';
+    this.value = '';
+    this.label = '';
+    this.helperText = '';
+    this.disabled = false;
+    this.fullWidth = false;
+    this.placeHolder = '';
+    this.rows = '';
+    this.cols = '';
+  }
+
+  // TODO(sorvell) #css: styling for fullwidth
+  _render({name, value, label, disabled, dense, fullWidth, required, placeHolder, helperText, rows, cols}) {
+    const hostClasses = c$({
+      'mdc-text-field--disabled': disabled,
+      'mdc-text-field--fullwidth': fullWidth,
+      'mdc-text-field--dense': dense
+    });
+    return html`
+      ${this._renderStyle()}
+      <div class$="mdc-text-field text-field mdc-text-field--textarea ${hostClasses}">
+        <textarea name=${name} id="text-field--textarea" placeholder$="${placeHolder}" required?="${required}" class$="mdc-text-field__input ${value ? 'mdc-text-field--upgraded' : ''}" value="${value}" rows$="${rows}" cols$="${cols}" aria-label$="${label}"></textarea>
+        <label for="text-field--textarea" class="mdc-floating-label">${label}</label>
+        ${!fullWidth ? html`<div class="mdc-line-ripple"></div>` : ''}
+      </div>
+      ${helperText ? html`<p class="mdc-text-field-helper-text" aria-hidden="true">${helperText}</p>` : ''}`;
+  }
+
+  ready() {
+    super.ready();
+    this._input = this._root.querySelector('textarea');
+  }
+
+}
+
+customElements.define('mwc-textarea', Textarea);

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@material/mwc-textarea",
+  "version": "0.1.0",
+  "description": "",
+  "main": "mwc-textarea.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@material/mwc-textfield": "^0.1.0"
+  },
+  "devDependencies": {
+  }
+}

--- a/test/unit/mwc-textarea.test.js
+++ b/test/unit/mwc-textarea.test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from 'chai';
+import {Textarea} from '@material/mwc-textarea';
+
+let element;
+
+suite('mwc-textarea');
+
+beforeEach(() => {
+  element = document.createElement('mwc-textarea');
+  document.body.appendChild(element);
+});
+
+afterEach(() => {
+  document.body.removeChild(element);
+});
+
+test('initializes as an mwc-textarea', () => {
+  assert.instanceOf(element, Textarea);
+});


### PR DESCRIPTION
Hi,
this is a proposal to add mwc-textarea component. I put it on a different directory to allow scripts to build it. I've also created/updated related files (demos, test).
What is missing : 
- there some missing events that i prefer to wait for this to be merged as textarea is a subclass of texfield : 
https://github.com/material-components/material-components-web-components/pull/46
- components properties and events needs to be documented 
- there are differences in behavior with the vanilla version that must be issued like helper text is always visible in vanilla.
Regards,
Cyrille