### PR TITLE
Update @webcomponents/webcomponentsjs to v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,7 +1334,7 @@
       "integrity": "sha512-7v/UlqVO05YuFCxxtC7jpuMQuDiPxArO7gACHqZ3uFd9/BM9YTdktX3bKRTnKTFUaPuNWWoPGvpAe2WOQCH2Pw==",
       "requires": {
         "@polymer/polymer": "3.0.2",
-        "lit-html": "0.10.1"
+        "lit-html": "0.10.2"
       }
     },
     "@polymer/polymer": {
@@ -1688,9 +1688,9 @@
       "integrity": "sha512-U/j4nODWIq0U9v0ll48dj4U4YgTqsVeRt0LKei0GA10JUpnZnORoIByY5+7m9G6KWIAj2mT9KtuUOnn7u93VXg=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.0.0-0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.0-0.tgz",
-      "integrity": "sha512-dEJm7EH35wm0lDrvi2cPy1MQN8sD6m/lJsTi8hi8YohHnm+P/1zyZbTU9NZC2G560SxU5c7a5Xdip+l6Fms6eg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.2.tgz",
+      "integrity": "sha512-+3515t7jnWsx+mNRECwXbjXBM0DLCNB4uH4DSIbu7akIJn0tO2GZuLvZeBhXbRFQLfohN+2ZTWT44A6EtPhVqA=="
     },
     "JSONStream": {
       "version": "1.3.2",
@@ -9068,9 +9068,9 @@
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
     },
     "lit-html": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-0.10.1.tgz",
-      "integrity": "sha512-aCBAc2O4jRL1mpT5LdkAHfB8dcG4WeA4a6GLEfUgPreVbzy2odoL95lnjsqVOWP/WhN7ZMuwgCvuyaA9rqsxUg=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-0.10.2.tgz",
+      "integrity": "sha512-ue0pIX3Fj5gUsNSozdRQIb1MAgNqFQsHgvHE/FU34xyu9NN/af3EISr7Bb+vP9YeLXIA4vLLOoYp2Z22dVYhww=="
     },
     "load-json-file": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "update-gh-pages": "npm run bootstrap && ./scripts/publish-demos.sh"
   },
   "devDependencies": {
-    "@webcomponents/webcomponentsjs": "^2.0.0-0",
+    "@webcomponents/webcomponentsjs": "^2.0.1",
     "babel-core": "^6.22.1",
     "babel-loader": "^7.0.0",
     "babel-plugin-transform-object-assign": "^6.8.0",


### PR DESCRIPTION
The elements in these packages depend on @polymer/lit-element@^0.5.2, which depend on lit-html@^0.10.0:

https://github.com/Polymer/lit-element/blob/v0.5.2/package.json#L39 (7f01cbb07645248b035fd824e5db62dd96bafaf8)

lit-html@0.10.1 includes changes which make it incompatible with shadycss <1.3.0:

https://github.com/Polymer/lit-html/commit/4dea332e7bc6153e749265323c7df85d4813757e

webcomponentsjs@2.0.1 is the first to build with shadycss >=1.3.0:

https://github.com/webcomponents/webcomponentsjs/blob/v2.0.0/package-lock.json#L1293 (df225f93b54f1944318931b770bc5c6b2d5de98d)
https://github.com/webcomponents/webcomponentsjs/blob/v2.0.1/package-lock.json#L1287 (c6a97da5621b2f40fe8046c8dd66febb5b0c8120)

cc @justinfagnani