### PR TITLE
Fix to Broken Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ If you've completed all of these steps the core team will do its best to respond
 
 Though the aim of the Polymer library is to allow lots of flexibility and not get in your way, we work to standardize our elements to make them as toolable and easy to maintain as possible.
 
-All elements should follow the [Polymer element style guide](http://polymerelements.github.io/style-guide/), which defines how to specify properties, documentation, and more. It's a great guide to follow when building your own elements as well, for maximum standardization and toolability. For instance, structuring elements following the style guide will ensure that they work with the [`iron-component-page`](https://github.com/polymerelements/iron-component-page) element, an incredibly easy way to turn any raw element directly into a documentation page.
+All elements should follow the [Polymer element style guide](https://github.com/PolymerElements/ContributionGuide/blob/master/CONTRIBUTING.md), which defines how to specify properties, documentation, and more. It's a great guide to follow when building your own elements as well, for maximum standardization and toolability. For instance, structuring elements following the style guide will ensure that they work with the [`iron-component-page`](https://github.com/polymerelements/iron-component-page) element, an incredibly easy way to turn any raw element directly into a documentation page.
 
 #### Contributing Code to the Polymer library
 


### PR DESCRIPTION
This change fixes the link to the Polymer Element Style Guide.

From 
http://polymerelements.github.io/style-guide/

to:
https://github.com/PolymerElements/ContributionGuide/blob/master/CONTRIBUTING.md