### PR TITLE
remove imports of afterNextRender (unused)

### DIFF
--- a/packages/select/mwc-select.js
+++ b/packages/select/mwc-select.js
@@ -21,7 +21,6 @@ import {MDCWCMenu} from '@material/mwc-menu/mwc-menu.js';
 import {MDCSelect} from '@material/select';
 import {style} from './mwc-select-css.js';
 import {style as menuStyle} from '@material/mwc-menu/mwc-menu-css.js';
-import {afterNextRender} from '@material/mwc-base/utils.js';
 
 // this element depend on the `mwc-list-item` and `mwc-list-item-separator`
 // elements to be registered ahead of time

--- a/packages/textfield/mwc-textfield.js
+++ b/packages/textfield/mwc-textfield.js
@@ -19,7 +19,6 @@ import {classMap} from 'lit-html/directives/classMap.js';
 import {MDCWebComponentMixin} from '@material/mwc-base/mdc-web-component.js';
 import {MDCTextField} from '@material/textfield';
 import {style} from './mwc-textfield-css.js';
-import {afterNextRender} from '@material/mwc-base/utils.js';
 import '@material/mwc-icon/mwc-icon-font.js';
 
 class MDCWCTextField extends MDCWebComponentMixin(MDCTextField) {}

--- a/test/unit/mwc-switch.test.js
+++ b/test/unit/mwc-switch.test.js
@@ -16,7 +16,6 @@
 
 import {assert} from 'chai';
 import {Switch} from '@material/mwc-switch';
-import {afterNextRender} from '@material/mwc-base/utils.js';
 
 let element;
 


### PR DESCRIPTION
utils.js doesn't export or even implement that function any more, trying to import it just causes errors 