### PR TITLE
Fix ripple directive for lit-html 0.13

### DIFF
--- a/packages/ripple/src/ripple-directive.ts
+++ b/packages/ripple/src/ripple-directive.ts
@@ -121,7 +121,7 @@ const rippleInteractionNodes = new WeakMap();
  * should be applied to a PropertyPart.
  * @param options {RippleOptions}
  */
-export const ripple = (options: RippleOptions = {}) => directive((part: PropertyPart) =>{
+export const ripple = directive((options: RippleOptions = {}) => (part: PropertyPart) => {
   const surfaceNode = part.committer.element as HTMLElement;
   const interactionNode = options.interactionNode || surfaceNode;
   let rippleFoundation = part.value;


### PR DESCRIPTION
In 144213a5403731775e3e92a6c9841f0227e5120a packages got dependencies updated for lit-html 0.13. However, there was a [breaking change](https://github.com/Polymer/lit-html/releases/tag/v0.13.0) in lit-html 0.13 that was not taken into account:

 - [Breaking] Directives are now defined by passing the entire directive factory function to directive(). (https://github.com/Polymer/lit-html/pull/562)

This PR will update the Ripple directive to use the new format.

CC @azakus