### PR TITLE
Adding checkedChange event to switch

### DIFF
--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -1,5 +1,5 @@
 # mwc-switch
-A [Material Components](https://material.io/components/) icon implementation using [Web Components](https://www.webcomponents.org/introduction)
+A [Material Components](https://material.io/components/) switch implementation using [Web Components](https://www.webcomponents.org/introduction)
 
 ## Getting started
 

--- a/packages/switch/src/mwc-switch.ts
+++ b/packages/switch/src/mwc-switch.ts
@@ -66,6 +66,8 @@ export class Switch extends FormElement {
     this.mdcFoundation.handleChange(e);
     // catch "click" event and sync properties
     this.checked = this.formElement.checked;
+    // fire "checkedChange" event to notify any parent elements
+    this.dispatchEvent(new CustomEvent('checkedChange', {bubbles: true, composed: true, detail: {value: this.checked}}));
   };
 
   protected readonly mdcFoundationClass: typeof SwitchFoundation = MDCSwitchFoundation;


### PR DESCRIPTION
allows parent elements to listen for when the checked property changes