### PR TITLE
Drawer: Slot app content

### DIFF
--- a/demos/drawer/dismissible.html
+++ b/demos/drawer/dismissible.html
@@ -35,19 +35,19 @@ limitations under the License.
       <mwc-icon-button icon="gesture"></mwc-icon-button>
       <mwc-icon-button icon="gavel"></mwc-icon-button>
     </div>
-  </mwc-drawer>
-  <div class="mdc-drawer-app-content">
-    <mwc-top-app-bar>
-      <mwc-icon-button slot="navigationIcon" icon="menu"></mwc-icon-button>
-      <div slot="title">Title</div>
-    </mwc-top-app-bar>
-    <div class="main-content">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div slot="appContent">
+      <mwc-top-app-bar>
+        <mwc-icon-button slot="navigationIcon" icon="menu"></mwc-icon-button>
+        <div slot="title">Title</div>
+      </mwc-top-app-bar>
+      <div class="main-content">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
     </div>
-  </div>
+  </mwc-drawer>
   <script src="drawer.js"></script>
 </body>
 </html>

--- a/demos/drawer/drawer.css
+++ b/demos/drawer/drawer.css
@@ -1,26 +1,8 @@
-body {
-  display: flex;
-  height: 100vh;
-}
-
-.mdc-drawer-app-content {
-  flex: auto;
-  overflow: auto;
-}
-
-mwc-top-app-bar {
-  position: absolute;
-}
-
-[type=dismissible][open] + .mdc-drawer-app-content {
-  margin-left: 256px;
-}
-
 .drawer-content {
   padding: 0px 16px 0 16px;
 }
 
 .main-content {
   min-height: 300px;
-  padding: 64px 18px 0 18px;
+  padding: 48px 18px 0 18px;
 }

--- a/demos/drawer/modal.html
+++ b/demos/drawer/modal.html
@@ -35,21 +35,21 @@ limitations under the License.
       <mwc-icon-button icon="gesture"></mwc-icon-button>
       <mwc-icon-button icon="gavel" id="gavel"></mwc-icon-button>
     </div>
-  </mwc-drawer>
-  <div class="mdc-drawer-app-content">
-    <mwc-top-app-bar>
-      <mwc-icon-button slot="navigationIcon" icon="menu"></mwc-icon-button>
-      <div slot="title">Title</div>
-      <mwc-icon-button slot="actionItems" icon="cast"></mwc-icon-button>
-      <mwc-icon-button slot="actionItems" icon="fingerprint"></mwc-icon-button>
-    </mwc-top-app-bar>
-    <div class="main-content">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div slot="appContent">
+      <mwc-top-app-bar>
+        <mwc-icon-button slot="navigationIcon" icon="menu"></mwc-icon-button>
+        <div slot="title">Title</div>
+        <mwc-icon-button slot="actionItems" icon="cast"></mwc-icon-button>
+        <mwc-icon-button slot="actionItems" icon="fingerprint"></mwc-icon-button>
+      </mwc-top-app-bar>
+      <div class="main-content">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
     </div>
-  </div>
+  </mwc-drawer>
   <script src="drawer.js"></script>
 </body>
 </html>

--- a/demos/drawer/standard.html
+++ b/demos/drawer/standard.html
@@ -26,16 +26,15 @@ limitations under the License.
   <link rel="stylesheet" href="drawer.css">
 </head>
 <body>
-    <mwc-drawer hasHeader>
-      <span slot="title">Drawer Title</span>
-      <span slot="subtitle">subtitle</span>
-      <div class="drawer-content">
-        <p>Drawer content!</p>
-        <p>With separate drawer scrolling.</p>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </div>
-    </mwc-drawer>
-    <div class="mdc-drawer-app-content">
+  <mwc-drawer hasHeader>
+    <span slot="title">Drawer Title</span>
+    <span slot="subtitle">subtitle</span>
+    <div class="drawer-content">
+      <p>Drawer content!</p>
+      <p>With separate drawer scrolling.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div slot="appContent">
       <mwc-top-app-bar>
         <div slot="title">Title</div>
       </mwc-top-app-bar>
@@ -46,5 +45,6 @@ limitations under the License.
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </div>
     </div>
+  </mwc-drawer>
 </body>
 </html>

--- a/packages/drawer/src/mwc-drawer.scss
+++ b/packages/drawer/src/mwc-drawer.scss
@@ -16,3 +16,12 @@ limitations under the License.
 */
 
 @import '@material/drawer/mdc-drawer.scss';
+
+.mdc-drawer-app-content {
+  flex: auto;
+  overflow: auto;
+}
+
+:host {
+  display: flex;
+}

--- a/packages/drawer/src/mwc-drawer.ts
+++ b/packages/drawer/src/mwc-drawer.ts
@@ -138,6 +138,9 @@ export class Drawer extends BaseElement {
         <div class="mdc-drawer__content"><slot></slot></div>
       </aside>
       ${modal ? html`<div class="mdc-drawer-scrim" @click="${this._handleScrimClick}"></div>` : ''}
+      <div class="mdc-drawer-app-content">
+        <slot name="appContent"></slot>
+      </div>
       `;
   }
 


### PR DESCRIPTION
Idea for adding .mdc-drawer-app-content styling to app content next to drawers.

With this solution, all app content would be light dom for the mwc-drawer component. I added `slot="appContent"` to a container div in the demos, but of course one could add `slot="appContent"` to each sibling of the drawer content.

We should probably discuss this solution and potential alternatives.

Fixes #193 