### PR TITLE
[Fix - Tab Bar Component]: Fix Transpiling to ES5

### DIFF
--- a/packages/tab-bar/src/mwc-tab-bar.ts
+++ b/packages/tab-bar/src/mwc-tab-bar.ts
@@ -80,6 +80,24 @@ export class TabBar extends BaseElement {
     this.mdcFoundation.handleKeyDown(e);
   }
 
+  constructor() {
+    super();
+
+    const updateComplete = this.updateComplete;
+
+    Object.defineProperty(this, 'updateComplete', {
+      get() {
+        return updateComplete
+          .then(() => this.scrollerElement.updateComplete)
+          .then(() => {
+            if (this.mdcFoundation === undefined) {
+              this.createFoundation();
+            }
+          });
+      }
+    });
+  }
+
   renderStyle() {
     return style;
   }
@@ -171,15 +189,6 @@ export class TabBar extends BaseElement {
   // This is necessary because the foundation/adapter synchronously addresses
   // the scroller element.
   firstUpdated() {}
-  get updateComplete() {
-    return super.updateComplete
-      .then(() => this.scrollerElement.updateComplete)
-      .then(() => {
-        if (this.mdcFoundation === undefined) {
-          this.createFoundation();
-        }
-      });
-  }
 
   scrollIndexIntoView(index: number) {
     this.mdcFoundation.scrollIntoView(index);


### PR DESCRIPTION
Calling `super` in a getter doesn't transpile to ES5. https://github.com/Microsoft/TypeScript/issues/338#issuecomment-347382190