### PR TITLE
Minimize direct imports of lit-html and lit-element

### DIFF
--- a/packages/base/src/base-element.ts
+++ b/packages/base/src/base-element.ts
@@ -16,8 +16,6 @@ limitations under the License.
 */
 
 import {LitElement} from 'lit-element';
-import {TemplateResult} from 'lit-html';
-export {TemplateResult};
 export * from 'lit-element';
 export {classMap} from 'lit-html/directives/class-map.js';
 export {observer} from './observer.js';

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -16,9 +16,7 @@
     "@material/button": "^0.40.0",
     "@material/mwc-base": "^0.3.5",
     "@material/mwc-icon": "^0.3.5",
-    "@material/mwc-ripple": "^0.3.5",
-    "lit-element": "^2.0.0-rc.2",
-    "lit-html": "^1.0.0-rc.2"
+    "@material/mwc-ripple": "^0.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, customElement} from 'lit-element';
-import {classMap} from 'lit-html/directives/class-map.js';
+import {LitElement, html, property, customElement, classMap} from '@material/mwc-base/base-element';
 import {style} from './mwc-button-css.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import '@material/mwc-icon/mwc-icon-font.js';

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "@material/checkbox": "^0.40.0",
     "@material/mwc-base": "^0.3.5",
-    "@material/mwc-ripple": "^0.3.5",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/mwc-ripple": "^0.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -15,9 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/drawer": "^0.40.0",
-    "@material/mwc-base": "^0.3.5",
-    "lit-element": "^2.0.0-rc.2",
-    "lit-html": "^1.0.0-rc.2"
+    "@material/mwc-base": "^0.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/drawer/src/mwc-drawer.ts
+++ b/packages/drawer/src/mwc-drawer.ts
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {BaseElement, html, property, observer, query, customElement, Adapter, Foundation, PropertyValues} from '@material/mwc-base/base-element.js';
-import {classMap} from 'lit-html/directives/class-map.js';
+import {BaseElement, html, property, observer, query, customElement, Adapter, Foundation, PropertyValues, classMap} from '@material/mwc-base/base-element.js';
 import MDCModalDrawerFoundation from '@material/drawer/modal/foundation.js';
 import MDCDismissibleDrawerFoundation from '@material/drawer/dismissible/foundation.js';
 import {strings} from '@material/drawer/constants.js';

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -16,9 +16,7 @@
     "@material/fab": "^0.40.0",
     "@material/mwc-base": "^0.3.5",
     "@material/mwc-icon": "^0.3.5",
-    "@material/mwc-ripple": "^0.3.5",
-    "lit-element": "^2.0.0-rc.2",
-    "lit-html": "^1.0.0-rc.2"
+    "@material/mwc-ripple": "^0.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fab/src/mwc-fab.ts
+++ b/packages/fab/src/mwc-fab.ts
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, customElement} from 'lit-element';
-import {classMap} from 'lit-html/directives/class-map.js';
+import {LitElement, html, property, customElement, classMap} from '@material/mwc-base/base-element';
 import {style} from './mwc-fab-css.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import '@material/mwc-icon/mwc-icon-font.js';

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -10,9 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/form-field": "^0.40.0",
-    "@material/mwc-base": "^0.3.5",
-    "lit-element": "^2.0.0-rc.2",
-    "lit-html": "^1.0.0-rc.2"
+    "@material/mwc-base": "^0.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/formfield/src/mwc-formfield.ts
+++ b/packages/formfield/src/mwc-formfield.ts
@@ -14,9 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {html, BaseElement, Foundation, Adapter, property, query, observer} from '@material/mwc-base/base-element.js';
+import {html, BaseElement, Foundation, Adapter, property, query, observer, classMap} from '@material/mwc-base/base-element.js';
 import {FormElement} from '@material/mwc-base/form-element.js';
-import {classMap} from 'lit-html/directives/class-map.js';
 import {findAssignedElement} from '@material/mwc-base/utils.js';
 import {style} from './mwc-formfield-css.js';
 import MDCFormFieldFoundation from '@material/form-field/foundation.js';

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -13,8 +13,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@material/mwc-base": "^0.3.5",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/mwc-base": "^0.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/icon/src/mwc-icon.ts
+++ b/packages/icon/src/mwc-icon.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, customElement} from 'lit-element';
+import {LitElement, html, customElement} from '@material/mwc-base/base-element';
 import {style} from './mwc-icon-host-css.js';
 import './mwc-icon-font.js';
 

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -10,8 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/linear-progress": "^0.40.0",
-    "@material/mwc-base": "^0.3.5",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/mwc-base": "^0.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
     "@material/mwc-ripple": "^0.3.5",
-    "@material/radio": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/radio": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
     "@material/ripple": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2",
     "lit-html": "^1.0.0-rc.2"
   },
   "publishConfig": {

--- a/packages/ripple/src/mwc-ripple.ts
+++ b/packages/ripple/src/mwc-ripple.ts
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, customElement} from 'lit-element';
-import {classMap} from 'lit-html/directives/class-map.js';
+import {LitElement, html, property, customElement, classMap} from '@material/mwc-base/base-element';
 import {ripple, RippleOptions} from './ripple-directive.js';
 import {style} from './mwc-ripple-css.js';
 

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
     "@material/slider": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2"
+    "lit-html": "^1.0.0-rc.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/slider/src/mwc-slider.ts
+++ b/packages/slider/src/mwc-slider.ts
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {FormElement, html, property, observer, query, customElement, Adapter, Foundation} from '@material/mwc-base/form-element.js';
-import {classMap} from 'lit-html/directives/class-map.js';
+import {FormElement, html, property, observer, query, customElement, Adapter, Foundation, classMap} from '@material/mwc-base/form-element.js';
 import {repeat} from 'lit-html/directives/repeat.js';
 import {style} from './mwc-slider-css.js';
 import MDCSliderFoundation from '@material/slider/foundation.js';

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -10,8 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
-    "@material/snackbar": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/snackbar": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
     "@material/mwc-ripple": "^0.3.5",
-    "@material/switch": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/switch": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -17,8 +17,7 @@
     "@material/mwc-base": "^0.3.5",
     "@material/mwc-tab": "^0.3.5",
     "@material/mwc-tab-scroller": "^0.3.5",
-    "@material/tab-bar": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/tab-bar": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -15,9 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
-    "@material/tab-indicator": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2",
-    "lit-html": "^1.0.0-rc.2"
+    "@material/tab-indicator": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-indicator/src/mwc-tab-indicator.ts
+++ b/packages/tab-indicator/src/mwc-tab-indicator.ts
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {BaseElement, html, property, query, customElement, Adapter, Foundation, PropertyValues} from '@material/mwc-base/base-element.js';
-import {classMap} from 'lit-html/directives/class-map.js';
+import {BaseElement, html, property, query, customElement, Adapter, Foundation, PropertyValues, classMap} from '@material/mwc-base/base-element.js';
 import MDCSlidingTabIndicatorFoundation from '@material/tab-indicator/sliding-foundation.js';
 import MDCFadingTabIndicatorFoundation from '@material/tab-indicator/fading-foundation.js';
 import {style} from './mwc-tab-indicator-css.js';

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -15,8 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
-    "@material/tab-scroller": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2"
+    "@material/tab-scroller": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -18,9 +18,7 @@
     "@material/mwc-icon": "^0.3.5",
     "@material/mwc-ripple": "^0.3.5",
     "@material/mwc-tab-indicator": "^0.3.5",
-    "@material/tab": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2",
-    "lit-html": "^1.0.0-rc.2"
+    "@material/tab": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab/src/mwc-tab.ts
+++ b/packages/tab/src/mwc-tab.ts
@@ -14,13 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {BaseElement, html, property, query, customElement, Adapter, Foundation} from '@material/mwc-base/base-element.js';
+import {BaseElement, html, property, query, customElement, Adapter, Foundation, classMap} from '@material/mwc-base/base-element.js';
 import {TabIndicator} from '@material/mwc-tab-indicator';
 
 // Make TypeScript not remove the import.
 import '@material/mwc-tab-indicator';
 
-import {classMap} from 'lit-html/directives/class-map';
 import {ripple} from '@material/mwc-ripple/ripple-directive';
 import MDCTabFoundation from '@material/tab/foundation';
 import {style} from './mwc-tab-css';

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -15,9 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.3.5",
-    "@material/top-app-bar": "^0.40.0",
-    "lit-element": "^2.0.0-rc.2",
-    "lit-html": "^1.0.0-rc.2"
+    "@material/top-app-bar": "^0.40.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/top-app-bar/src/mwc-top-app-bar.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar.ts
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {BaseElement, html, property, query, customElement, Adapter, Foundation, PropertyValues} from '@material/mwc-base/base-element.js';
-import {classMap} from 'lit-html/directives/class-map.js';
+import {BaseElement, html, property, query, customElement, Adapter, Foundation, PropertyValues, classMap} from '@material/mwc-base/base-element.js';
 import MDCTopAppBarFoundation from '@material/top-app-bar/standard/foundation.js';
 import MDCShortTopAppBarFoundation from '@material/top-app-bar/short/foundation.js';
 import MDCFixedTopAppBarFoundation from '@material/top-app-bar/fixed/foundation.js';

--- a/sass-template.tmpl
+++ b/sass-template.tmpl
@@ -14,6 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {css} from 'lit-element';
+import {css} from '@material/mwc-base/base-element';
 
 export const style = css`<% content %>`;


### PR DESCRIPTION
mwc-base exports everything needed by the majority of elements.

This will reduce maintenance on updating lit versions.