### PR TITLE
TabBar: RTL support

### DIFF
--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -24,6 +24,13 @@ limitations under the License.
   <script type="module" src="../node_modules/@material/mwc-tab-bar/mwc-tab-bar.js"></script>
   <script type="module" src="../node_modules/@material/mwc-icon/mwc-icon.js"></script>
   <link rel="stylesheet" href="demo-component.css">
+  <style>
+    iframe {
+      border: 1px solid gray;
+      height: 380px;
+      width: 100%;
+    }
+  </style>
 </head>
 <body class="unresolved">
   <header>
@@ -129,6 +136,9 @@ limitations under the License.
       <mwc-tab icon="accessibility" isFadingIndicator indicatorIcon="donut_large"></mwc-tab>
       <mwc-tab icon="exit_to_app" isFadingIndicator indicatorIcon="donut_large"></mwc-tab>
     </mwc-tab-bar>
+
+    <h3>RTL</h3>
+    <iframe src="tabs/rtl.html"></iframe>
   </main>
 
   <script>

--- a/demos/tabs/rtl.html
+++ b/demos/tabs/rtl.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<!--
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html dir="rtl">
+<head>
+  <title>tabs demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script type="module" src="../../node_modules/@material/mwc-tab/mwc-tab.js"></script>
+  <script type="module" src="../../node_modules/@material/mwc-tab-bar/mwc-tab-bar.js"></script>
+  <script type="module" src="../../node_modules/@material/mwc-icon/mwc-icon.js"></script>
+  <link rel="stylesheet" href="../demo-component.css">
+  <style>
+    main {
+      margin-top: 0;
+    }
+  </style>
+</head>
+<body class="unresolved">
+  <main>
+    <h3>RTL</h3>
+    <mwc-tab-bar>
+      <mwc-tab label="one"></mwc-tab>
+      <mwc-tab label="two"></mwc-tab>
+      <mwc-tab label="three"></mwc-tab>
+    </mwc-tab-bar>
+
+    <h3>RTL With Icons</h3>
+    <mwc-tab-bar activeIndex="2">
+      <mwc-tab label="one" icon="accessibility"></mwc-tab>
+      <mwc-tab label="two" icon="exit_to_app"></mwc-tab>
+      <mwc-tab label="three" icon="camera"></mwc-tab>
+    </mwc-tab-bar>
+
+    <h3>RTL Scrolling</h3>
+    <mwc-tab-bar>
+      <mwc-tab label="one" icon="laptop" stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="two" icon="laptop_chrome" stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="three" icon="laptop_mac" stacked isMinWidthIndicator ></mwc-tab>
+      <mwc-tab label="four" icon="laptop_windows" stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="five" icon="phone_android" stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="six" icon="phone_iphone" stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="seven" icon="smartphone" stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="eight" icon="tablet" stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="nine" icon="tablet_android"  stacked isMinWidthIndicator></mwc-tab>
+      <mwc-tab label="ten" icon="tablet_mac" stacked isMinWidthIndicator></mwc-tab>
+    </mwc-tab-bar>
+  </main>
+
+  <script>
+    addEventListener('load', () => document.body.classList.remove('unresolved'));
+  </script>
+</body>
+</html>

--- a/packages/tab-bar/src/mwc-tab-bar.ts
+++ b/packages/tab-bar/src/mwc-tab-bar.ts
@@ -88,7 +88,7 @@ export class TabBar extends BaseElement {
       <div class="mdc-tab-bar" role="tablist"
           @MDCTab:interacted="${this._handleTabInteraction}"
           @keydown="${this._handleKeydown}">
-        <mwc-tab-scroller><slot></slot></mwc-tab-scroller>
+        <mwc-tab-scroller dir="${this.dir}"><slot></slot></mwc-tab-scroller>
       </div>
       `;
   }

--- a/packages/tab/src/mwc-tab.scss
+++ b/packages/tab/src/mwc-tab.scss
@@ -37,3 +37,22 @@ limitations under the License.
 .mdc-tab::-moz-focus-inner {
   border: 0;
 }
+
+@mixin mdc-rtl($root-selector: null) {
+  @if ($root-selector) {
+    @at-root {
+      #{$root-selector}[dir="rtl"] &,
+      [dir="rtl"] #{$root-selector} & {
+        @content;
+      }
+    }
+  } @else {
+    :host([dir="rtl"]) & {
+      @content;
+    }
+  }
+}
+
+.mdc-tab:not(.mdc-tab--stacked) .mdc-tab__icon + .mdc-tab__text-label {
+  @include mdc-rtl-reflexive-box(padding, left, 8px);
+}

--- a/packages/tab/src/mwc-tab.ts
+++ b/packages/tab/src/mwc-tab.ts
@@ -98,6 +98,11 @@ export class Tab extends BaseElement {
     return this.attachShadow({mode: 'open', delegatesFocus: true});
   }
 
+  connectedCallback() {
+    this.dir = document.dir;
+    super.connectedCallback();
+  }
+
   static styles = style;
 
   render() {


### PR DESCRIPTION
Add RTL support to `mwc-tab-bar`.

How: Create a property for [dir](http://mdn.io/dir) on `mwc-tab-bar` and pass it to to mwc-tab-scroller. Specifically, this gives `.mdc-tab-scroller__scroll-content` in the `mwc-tab-scroller` a computed `direction` value, which allows RTL scrolling to work properly.

fixes: #194 