### PR TITLE
Drawer: Fix host height

### DIFF
--- a/demos/drawer/drawer.css
+++ b/demos/drawer/drawer.css
@@ -1,3 +1,7 @@
+body {
+  height: 100vh;
+}
+
 .drawer-content {
   padding: 0px 16px 0 16px;
 }

--- a/packages/drawer/src/mwc-drawer.scss
+++ b/packages/drawer/src/mwc-drawer.scss
@@ -18,10 +18,10 @@ limitations under the License.
 @import '@material/drawer/mdc-drawer.scss';
 
 .mdc-drawer-app-content {
-  flex: auto;
   overflow: auto;
 }
 
 :host {
   display: flex;
+  height: 100%;
 }


### PR DESCRIPTION
The mwc-drawer host element should have a height of 100%. This allows the drawer and main content (styled by mdc) to also span 100% of the containing element's height.