### PR TITLE
Drawer: Fix focus trap for new appContent slot

### DIFF
--- a/packages/drawer/src/mwc-drawer.ts
+++ b/packages/drawer/src/mwc-drawer.ts
@@ -33,6 +33,10 @@ declare global {
       remove(HTMLElement): Boolean;
     }
   }
+
+  interface HTMLElement {
+    inert: Boolean;
+  }
 }
 
 export interface DrawerFoundation extends Foundation {
@@ -51,6 +55,9 @@ export class Drawer extends BaseElement {
   @query('.mdc-drawer')
   protected mdcRoot!: HTMLElement;
 
+  @query('.mdc-drawer-app-content')
+  protected appContent!: HTMLElement;
+
   protected mdcFoundation!: MDCDismissibleDrawerFoundation|MDCModalDrawerFoundation;
 
   protected get mdcFoundationClass(): typeof DrawerFoundation {
@@ -68,6 +75,7 @@ export class Drawer extends BaseElement {
       },
       restoreFocus: () => {
         document.$blockingElements.remove(this);
+        this.appContent.inert = false;
         const previousFocus = this._previousFocus && this._previousFocus.focus;
         if (previousFocus) {
           this._previousFocus!.focus();
@@ -86,6 +94,7 @@ export class Drawer extends BaseElement {
       },
       trapFocus: () => {
         document.$blockingElements.push(this);
+        this.appContent.inert = true;
       },
     }
   }


### PR DESCRIPTION
The focus trap behavior regressed when the `appContent` slot was introduced (Let's get integration tests). Frankie is right in #221: When the mdcRoot is added to $blockingElements, only the siblings of the parents are made inert. Since the `aside`, `scrim`, and `appContent` are all siblings, we have to get away with directly setting `inert` on appContent. We retain the $blockingElements usage for cases in which there are further ancestors.

Fixes: #221 