### PR TITLE
Disable pointer events when button is disabled

### DIFF
--- a/packages/button/src/mwc-button.scss
+++ b/packages/button/src/mwc-button.scss
@@ -27,6 +27,10 @@ limitations under the License.
   outline: none;
 }
 
+:host([disabled]) {
+  pointer-events: none;
+}
+
 .mdc-button {
   flex: 1;
 }

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, observer, customElement, classMap} from '@material/mwc-base/base-element';
+import {LitElement, html, property, customElement, classMap} from '@material/mwc-base/base-element';
 import {style} from './mwc-button-css.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import '@material/mwc-icon/mwc-icon-font.js';

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -34,10 +34,7 @@ export class Button extends LitElement {
   @property({type: Boolean})
   dense = false;
 
-  @observer(function(this: LitElement, value: boolean) {
-    this.style.pointerEvents = value ? 'none' : '';
-  })
-  @property({type: Boolean})
+  @property({type: Boolean, reflect: true})
   disabled = false;
 
   @property({type: Boolean})

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, customElement, classMap} from '@material/mwc-base/base-element';
+import {LitElement, html, property, observer, customElement, classMap} from '@material/mwc-base/base-element';
 import {style} from './mwc-button-css.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import '@material/mwc-icon/mwc-icon-font.js';
@@ -34,6 +34,9 @@ export class Button extends LitElement {
   @property({type: Boolean})
   dense = false;
 
+  @observer(function(this: LitElement, value: boolean) {
+    this.style.pointerEvents = value ? 'none' : '';
+  })
   @property({type: Boolean})
   disabled = false;
 


### PR DESCRIPTION
Disable pointer events when `<mwc-button>` is disabled.

Approach copied from how Polymer implements similar functionality: https://github.com/PolymerElements/iron-behaviors/blob/master/iron-control-state.js#L76-L95

Fixes #148 