### PR TITLE
Drawer: Use fixed focus trap lifecycle

### DIFF
--- a/packages/drawer/src/mwc-drawer.ts
+++ b/packages/drawer/src/mwc-drawer.ts
@@ -74,8 +74,6 @@ export class Drawer extends BaseElement {
         this._previousFocus = (this.getRootNode() as any as DocumentOrShadowRoot).activeElement as HTMLElement|null;
       },
       restoreFocus: () => {
-        document.$blockingElements.remove(this);
-        this.appContent.inert = false;
         const previousFocus = this._previousFocus && this._previousFocus.focus;
         if (previousFocus) {
           this._previousFocus!.focus();
@@ -95,6 +93,10 @@ export class Drawer extends BaseElement {
       trapFocus: () => {
         document.$blockingElements.push(this);
         this.appContent.inert = true;
+      },
+      releaseFocus: () => {
+        document.$blockingElements.remove(this);
+        this.appContent.inert = false;
       },
     }
   }


### PR DESCRIPTION
I raised [this issue](https://github.com/material-components/material-components-web/issues/4268) in material-web-components regarding the ordering of `releaseFocus` and `restoreFocus` for the mdc-drawer component. The fix for this issue was [merged](https://github.com/material-components/material-components-web/pull/4304), and finally released as part of [v.0.44](https://github.com/material-components/material-components-web/releases/tag/v0.44.0).

Now that we're up to date with v.0.44, this PR implements the releasing of focus in the proper lifecycle method (`releaseFocus`, not `restoreFocus`).