### PR TITLE
TopAppBar: Add centered title option

### DIFF
--- a/demos/top-app-bar.html
+++ b/demos/top-app-bar.html
@@ -95,6 +95,7 @@ limitations under the License.
       </select>
       <label><input id="dense" type="checkbox"> Dense</label>
       <label><input id="extraRow" type="checkbox"> Extra Row</label>
+      <label><input id="centerTitle" type="checkbox"> Center Title</label>
     </div>
     <div class="view">
       <mwc-top-app-bar>
@@ -146,6 +147,7 @@ limitations under the License.
 
     dense.addEventListener('change', (e) => bar.dense = e.target.checked);
     extraRow.addEventListener('change', (e) => bar.extraRow = e.target.checked);
+    centerTitle.addEventListener('change', (e) => bar.centerTitle = e.target.checked);
   </script>
 </body>
 </html>

--- a/packages/top-app-bar/src/mwc-top-app-bar.scss
+++ b/packages/top-app-bar/src/mwc-top-app-bar.scss
@@ -40,9 +40,6 @@ limitations under the License.
   .mdc-top-app-bar__section--align-end {
     flex-basis: 0%;
   }
-  .mdc-top-app-bar__row {
-    justify-content: center;
-  }
 }
 
 .mdc-top-app-bar--prominent {

--- a/packages/top-app-bar/src/mwc-top-app-bar.scss
+++ b/packages/top-app-bar/src/mwc-top-app-bar.scss
@@ -25,6 +25,26 @@ limitations under the License.
   flex: 1;
 }
 
+.mdc-top-app-bar__section--align-center {
+  justify-content: center;
+
+  .mdc-top-app-bar__title {
+    padding-left: 0;
+  }
+}
+
+.mwc-top-app-bar--center-title {
+  .mdc-top-app-bar__section--align-start {
+    flex-basis: 0%;
+  }
+  .mdc-top-app-bar__section--align-end {
+    flex-basis: 0%;
+  }
+  .mdc-top-app-bar__row {
+    justify-content: center;
+  }
+}
+
 .mdc-top-app-bar--prominent {
   slot[name="navigationIcon"]::slotted(*),
   slot[name="actionItems"]::slotted(*) {

--- a/packages/top-app-bar/src/mwc-top-app-bar.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar.ts
@@ -65,6 +65,9 @@ export class TopAppBar extends BaseElement {
   @property({type: Boolean, reflect: true})
   extraRow = false;
 
+  @property({type: Boolean, reflect: true})
+  centerTitle = false;
+
   private _scrollTarget!: HTMLElement|Window;
 
   get scrollTarget() {
@@ -88,7 +91,8 @@ export class TopAppBar extends BaseElement {
       'mdc-top-app-bar--short': this.type === 'shortCollapsed' || this.type === 'short',
       'mdc-top-app-bar--short-collapsed': this.type === 'shortCollapsed',
       'mdc-top-app-bar--prominent': this.type === 'prominent' || this.type === 'prominentFixed',
-      'mdc-top-app-bar--dense': this.dense
+      'mdc-top-app-bar--dense': this.dense,
+      'mwc-top-app-bar--center-title': this.centerTitle
     };
     const extraRow = this.extraRow ? html`
       <div class="mdc-top-app-bar__row">
@@ -96,13 +100,21 @@ export class TopAppBar extends BaseElement {
           <slot name="extraRow"></slot>
         </section>
       </div>` : '';
+    const alignStartTitle = !this.centerTitle ? html`
+      <span class="mdc-top-app-bar__title"><slot name="title"></slot></span>
+    ` : '';
+    const centerSection = this.centerTitle ? html`
+      <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
+        <span class="mdc-top-app-bar__title"><slot name="title"></slot></span>
+      </section>` : '';
     return html`
       <header class="mdc-top-app-bar ${classMap(classes)}">
       <div class="mdc-top-app-bar__row">
         <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
           <slot name="navigationIcon"></slot>
-          <span class="mdc-top-app-bar__title"><slot name="title"></slot></span>
+          ${alignStartTitle}
         </section>
+        ${centerSection}
         <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
           <slot name="actionItems"></slot>
         </section>


### PR DESCRIPTION
Allow the title to be centered on the Top App Bar. The option is exposed as a boolean property on the host called `centerTitle`. Open to suggestions on this API choice.

![demo top app bar](https://user-images.githubusercontent.com/7411489/53116525-bdf79380-34fd-11e9-8f03-66230500fdd7.png)

_Note: This is not a built-in feature from the material spec._ That being said, centered titles are featured in some of the Material custom theme case studies. (see "Rally Theme" from [Top App Bar spec](https://material.io/design/components/app-bars-top.html#theming))

closes #189 