### PR TITLE
add repository url to mdc-form-field package

### DIFF
--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.6",
   "description": "",
   "main": "mwc-formfield.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web-components.git"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This should fix the error shown @ [https://www.webcomponents.org/element/@material/mwc-formfield](https://www.webcomponents.org/element/@material/mwc-formfield).

---

<h3 class="style-scope catalog-error">Error  - 15</h3>
<h1 class="page-title style-scope catalog-error">Unable to process element</h1>
<h2 class="page-subtitle style-scope catalog-error">{"message": "No github URL associated with package", "code": 15}</h2>
