### PR TITLE
Fix <mwc-button> width in IE11

### DIFF
--- a/packages/button/src/mwc-button.scss
+++ b/packages/button/src/mwc-button.scss
@@ -32,5 +32,5 @@ limitations under the License.
 }
 
 .mdc-button {
-  flex: 1;
+  flex: auto;
 }


### PR DESCRIPTION
`flex:1` does not seem to behave the same in IE11 as other browsers, but `flex:auto` works consistently here. Confirmed with internal screenshot tests.