### PR TITLE
chore: add `repository.directory` in `package.json` for all packages

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/base"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-button.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/button"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-checkbox.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/checkbox"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-drawer.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/drawer"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-fab.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/fab"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -3,6 +3,11 @@
   "version": "0.6.0",
   "description": "",
   "main": "mwc-formfield.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/formfield"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -3,6 +3,11 @@
   "version": "0.6.0",
   "description": "",
   "main": "mwc-icon-button.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/icon-button"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-icon.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/icon"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -3,6 +3,11 @@
   "version": "0.6.0",
   "description": "",
   "main": "mwc-linear-progress.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/icon-button"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-radio.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/radio"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-ripple.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/ripple"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -3,6 +3,11 @@
   "version": "0.6.0",
   "description": "",
   "main": "mwc-slider.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/slider"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -3,6 +3,11 @@
   "version": "0.6.0",
   "description": "",
   "main": "mwc-snackbar.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/snackbar"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-switch.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/switch"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-tab-bar.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/tab-bar"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-tab-indicator.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/tab-indicator"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-tab-scroller.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/tab-scroller"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-tab.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/tab"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -5,7 +5,8 @@
   "main": "mwc-top-app-bar.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web-components.git"
+    "url": "https://github.com/material-components/material-components-web-components.git",
+    "directory": "packages/top-app-bar"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This is the new way to mark a package in a monorepo.
See [repository.directory](https://docs.npmjs.com/files/package.json#repository) property in `package.json`.
In a future release of `npmjs.com` this will allow to link directly to a package in a monorepo.

https://docs.npmjs.com/files/package.json#repository  
https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md

Related https://github.com/material-components/material-components-web/pull/4897
Related https://github.com/material-components/material-components-web-react/pull/975