### PR TITLE
Fix tachometer

### DIFF
--- a/test/benchmark/helpers.ts
+++ b/test/benchmark/helpers.ts
@@ -88,11 +88,20 @@ export const fixture = (
   return tf;
 };
 
+interface MeasureFixtureCreationOpts {
+  afterRender?: (root: ShadowRoot) => Promise<unknown>;
+  numRenders: number;
+}
+
+const defaultMeasureOpts = {
+  numRenders: 10,
+}
+
 export const measureFixtureCreation = async (
     template: TemplateResult,
-    afterRender?: (fixture: ShadowRoot) => Promise<unknown>,
-    numRenders = 100) => {
-  const templates = new Array<TemplateResult>(numRenders).fill(template);
+    options?: Partial<MeasureFixtureCreationOpts>) => {
+  const opts: MeasureFixtureCreationOpts = {...defaultMeasureOpts, ...options};
+  const templates = new Array<TemplateResult>(opts.numRenders).fill(template);
   const renderContainer = document.createElement('div');
   const renderTargetRoot = renderContainer.attachShadow({mode: 'open'});
 
@@ -108,8 +117,8 @@ export const measureFixtureCreation = async (
     await new Promise(res => requestAnimationFrame(() => res));
   }
 
-  if (afterRender) {
-    afterRender(renderTargetRoot);
+  if (opts.afterRender) {
+    opts.afterRender(renderTargetRoot);
   }
 
   const end = performance.now();

--- a/test/benchmark/helpers.ts
+++ b/test/benchmark/helpers.ts
@@ -114,7 +114,7 @@ export const measureFixtureCreation = async (
     await (firstChild as LitElement).updateComplete;
     document.body.offsetWidth;
   } else {
-    await new Promise(res => requestAnimationFrame(() => res));
+    await new Promise(res => requestAnimationFrame(res));
   }
 
   if (opts.afterRender) {

--- a/test/benchmark/snackbar/test-basic.ts
+++ b/test/benchmark/snackbar/test-basic.ts
@@ -9,7 +9,7 @@ measureFixtureCreation(html`
     <div id="actionButton" slot="action">RETRY</div>
     <div id="iconButton" slot="dismiss">DISMISS</div>
   </mwc-snackbar>
-`, async (fixture) => {
-  const snackbar = fixture.root.querySelector('#snack1') as Snackbar;
+`, async (root) => {
+  const snackbar = root.querySelector('#snack1') as Snackbar;
   snackbar.open();
 });

--- a/test/benchmark/snackbar/test-basic.ts
+++ b/test/benchmark/snackbar/test-basic.ts
@@ -9,7 +9,9 @@ measureFixtureCreation(html`
     <div id="actionButton" slot="action">RETRY</div>
     <div id="iconButton" slot="dismiss">DISMISS</div>
   </mwc-snackbar>
-`, async (root) => {
-  const snackbar = root.querySelector('#snack1') as Snackbar;
-  snackbar.open();
+`, {
+  afterRender: async (root) => {
+    const snackbar = root.querySelector('#snack1') as Snackbar;
+    snackbar.open();
+  }
 });


### PR DESCRIPTION
There was a problem where our tachometer implementation using RAF would not paint the elements onto the page / do style recalculation before measuring.

I instead switched from using the lit element `test-fixture` and instead simply use `lit-html`'s render method and checking the first child and awaiting `updateComplete` + forcing style recalc w/ `offsetWidth`.

If there is no first child with `updateComplete` we just simply await a RAF.

Also changed the test harness interface to take an object of options rather than params.

fixes #312.