### PR TITLE
Don't automatically import Material Icons font.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Components no longer automatically load the Material Icons font, so that
+  users have control over how fonts are loaded. Users can still import the
+  `mwc-icon-font.js` module themselves to automatically load the font from
+  fonts.googleapis.com.
+
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x
 - Upgrade typescript to 3.4, add config for tsbuildinfo files needed for incremental compilation mode

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import {ButtonBase} from './mwc-button-base.js';
 import {customElement} from '@material/mwc-base/base-element';
 import {style} from './mwc-button-css.js';
-import '@material/mwc-icon/mwc-icon-font.js';
 
 @customElement('mwc-button' as any)
 export class Button extends ButtonBase {

--- a/packages/fab/src/mwc-fab.ts
+++ b/packages/fab/src/mwc-fab.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import {FabBase} from './mwc-fab-base.js';
 import {customElement} from '@material/mwc-base/base-element';
 import {style} from './mwc-fab-css.js';
-import '@material/mwc-icon/mwc-icon-font.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/icon-button/src/mwc-icon-button.ts
+++ b/packages/icon-button/src/mwc-icon-button.ts
@@ -18,7 +18,6 @@ limitations under the License.
 import {IconButtonBase} from './icon-button-base.js';
 import {style} from './mwc-icon-button-css.js';
 import {customElement} from '@material/mwc-base/base-element.js';
-import '@material/mwc-icon/mwc-icon-font.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/icon/src/mwc-icon.ts
+++ b/packages/icon/src/mwc-icon.ts
@@ -16,7 +16,6 @@ limitations under the License.
 */
 import {LitElement, html, customElement} from '@material/mwc-base/base-element';
 import {style} from './mwc-icon-host-css.js';
-import './mwc-icon-font.js';
 
 @customElement('mwc-icon' as any)
 export class Icon extends LitElement {


### PR DESCRIPTION
We don't want to force users to load the Material Icons font in any particular way. For example, users may want to load Roboto and Icons with one request (e.g. `https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono|Material+Icons`), or they might want to host their own version.

The `mwc-icon-font` module can still be imported by the user (which adds a `<link>` to the head) if they want this easy option.

Fixes #195 
Fixes #90 