### PR TITLE
clang-format with new config

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,7 +15,7 @@ parserOptions:
   sourceType: module
 rules:
   indent: off
-  max-len: [warn, 120]
+  max-len: off # clang-format fixes line lengths
   no-new: warn
   quotes: [error, single, {"avoidEscape": true}]
   no-var: error
@@ -33,6 +33,7 @@ rules:
   valid-jsdoc: off
 
   prefer-const: error
+  comma-dangle: off
 
   # Rules for our mocha unit tests. Note that even though we use mocha, we model our unit tests
   # after frameworks such as tape and ava, which encourage modern paradigms, seek to minimize

--- a/package-lock.json
+++ b/package-lock.json
@@ -7254,8 +7254,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7279,15 +7278,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7304,22 +7301,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7450,8 +7444,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7465,7 +7458,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7482,7 +7474,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7491,15 +7482,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7520,7 +7509,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7609,8 +7597,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7624,7 +7611,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7720,8 +7706,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7763,7 +7748,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7785,7 +7769,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7834,15 +7817,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean:typescript": "npm run build:typescript -- --clean",
     "clean:styles": "del-cli packages/*/src/*-css.ts",
     "dev": "polyserve --npm --module-resolution=node",
-    "format": "clang-format --version; find packages | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i",
+    "format": "clang-format --version; find . -name '*.ts' | grep -v node_modules | xargs clang-format -style=file -i",
     "lint:imports": "node scripts/check-imports.js",
     "lint": "npm run lint:typescript",
     "lint:typescript": "eslint \"packages/**/*.ts\"",

--- a/packages/base/src/base-element.ts
+++ b/packages/base/src/base-element.ts
@@ -15,8 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {LitElement} from 'lit-element';
 import {MDCFoundation} from '@material/base';
+import {LitElement} from 'lit-element';
+
 import {Constructor} from './utils.js';
 
 export * from 'lit-element';

--- a/packages/button/src/mwc-button-base.ts
+++ b/packages/button/src/mwc-button-base.ts
@@ -14,33 +14,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, classMap} from '@material/mwc-base/base-element';
+import {classMap, html, LitElement, property} from '@material/mwc-base/base-element';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 
 export class ButtonBase extends LitElement {
-  @property({type: Boolean})
-  raised = false;
+  @property({type: Boolean}) raised = false;
 
-  @property({type: Boolean})
-  unelevated = false;
+  @property({type: Boolean}) unelevated = false;
 
-  @property({type: Boolean})
-  outlined = false;
+  @property({type: Boolean}) outlined = false;
 
-  @property({type: Boolean})
-  dense = false;
+  @property({type: Boolean}) dense = false;
 
-  @property({type: Boolean, reflect: true})
-  disabled = false;
+  @property({type: Boolean, reflect: true}) disabled = false;
 
-  @property({type: Boolean})
-  trailingIcon = false;
+  @property({type: Boolean}) trailingIcon = false;
 
-  @property()
-  icon = '';
+  @property() icon = '';
 
-  @property()
-  label = '';
+  @property() label = '';
 
   createRenderRoot() {
     return this.attachShadow({mode: 'open', delegatesFocus: true});
@@ -53,10 +45,13 @@ export class ButtonBase extends LitElement {
       'mdc-button--outlined': this.outlined,
       'mdc-button--dense': this.dense,
     };
-    const mdcButtonIcon = html`<span class="material-icons mdc-button__icon">${this.icon}</span>`;
+    const mdcButtonIcon =
+        html`<span class="material-icons mdc-button__icon">${this.icon}</span>`;
     return html`
       <button
-          .ripple="${ripple({unbounded: false})}"
+          .ripple="${ripple({
+      unbounded: false
+    })}"
           class="mdc-button ${classMap(classes)}"
           ?disabled="${this.disabled}"
           aria-label="${this.label || this.icon}">

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {ButtonBase} from './mwc-button-base.js';
 import {customElement} from '@material/mwc-base/base-element';
+
+import {ButtonBase} from './mwc-button-base.js';
 import {style} from './mwc-button-css.js';
 
 @customElement('mwc-button' as any)

--- a/packages/checkbox/src/mwc-checkbox-base.ts
+++ b/packages/checkbox/src/mwc-checkbox-base.ts
@@ -14,32 +14,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  html,
-  FormElement,
-  property,
-  query,
-  observer,
-  HTMLElementWithRipple,
-  addHasRemoveClass,
-  RippleSurface,
-} from '@material/mwc-base/form-element.js';
-import {ripple} from '@material/mwc-ripple/ripple-directive.js';
-import MDCCheckboxFoundation from '@material/checkbox/foundation.js';
 import {MDCCheckboxAdapter} from '@material/checkbox/adapter.js';
+import MDCCheckboxFoundation from '@material/checkbox/foundation.js';
+import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query, RippleSurface,} from '@material/mwc-base/form-element.js';
+import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 
 export class CheckboxBase extends FormElement {
-  @query('.mdc-checkbox')
-  protected mdcRoot!: HTMLElementWithRipple;
+  @query('.mdc-checkbox') protected mdcRoot!: HTMLElementWithRipple;
 
-  @query('input')
-  protected formElement!: HTMLInputElement;
+  @query('input') protected formElement!: HTMLInputElement;
 
-  @property({type: Boolean})
-  checked = false;
+  @property({type: Boolean}) checked = false;
 
-  @property({type: Boolean})
-  indeterminate = false;
+  @property({type: Boolean}) indeterminate = false;
 
   @property({type: Boolean})
   @observer(function(this: CheckboxBase, value: boolean) {
@@ -50,11 +37,11 @@ export class CheckboxBase extends FormElement {
   @property({type: String})
   value = ''
 
-  protected mdcFoundationClass = MDCCheckboxFoundation;
+      protected mdcFoundationClass = MDCCheckboxFoundation;
 
   protected mdcFoundation!: MDCCheckboxFoundation;
 
-  get ripple(): RippleSurface | undefined {
+  get ripple(): RippleSurface|undefined {
     return this.mdcRoot.ripple;
   }
 
@@ -82,7 +69,8 @@ export class CheckboxBase extends FormElement {
 
   render() {
     return html`
-      <div class="mdc-checkbox" @animationend="${this._animationEndHandler}" .ripple="${ripple()}">
+      <div class="mdc-checkbox" @animationend="${
+        this._animationEndHandler}" .ripple="${ripple()}">
         <input type="checkbox"
               class="mdc-checkbox__native-control"
               @change="${this._changeHandler}"

--- a/packages/checkbox/src/mwc-checkbox-base.ts
+++ b/packages/checkbox/src/mwc-checkbox-base.ts
@@ -34,10 +34,9 @@ export class CheckboxBase extends FormElement {
   })
   disabled = false;
 
-  @property({type: String})
-  value = ''
+  @property({type: String}) value = '';
 
-      protected mdcFoundationClass = MDCCheckboxFoundation;
+  protected mdcFoundationClass = MDCCheckboxFoundation;
 
   protected mdcFoundation!: MDCCheckboxFoundation;
 

--- a/packages/checkbox/src/mwc-checkbox-base.ts
+++ b/packages/checkbox/src/mwc-checkbox-base.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import {MDCCheckboxAdapter} from '@material/checkbox/adapter.js';
 import MDCCheckboxFoundation from '@material/checkbox/foundation.js';
-import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query, RippleSurface,} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query, RippleSurface} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 
 export class CheckboxBase extends FormElement {

--- a/packages/checkbox/src/mwc-checkbox.ts
+++ b/packages/checkbox/src/mwc-checkbox.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {CheckboxBase} from './mwc-checkbox-base.js';
 import {customElement} from '@material/mwc-base/form-element.js';
+
+import {CheckboxBase} from './mwc-checkbox-base.js';
 import {style} from './mwc-checkbox-css.js';
 
 declare global {

--- a/packages/drawer/src/mwc-drawer-base.ts
+++ b/packages/drawer/src/mwc-drawer-base.ts
@@ -20,7 +20,7 @@ import {MDCDrawerAdapter} from '@material/drawer/adapter.js';
 import {strings} from '@material/drawer/constants.js';
 import MDCDismissibleDrawerFoundation from '@material/drawer/dismissible/foundation.js';
 import MDCModalDrawerFoundation from '@material/drawer/modal/foundation.js';
-import {addHasRemoveClass, BaseElement, classMap, html, observer, property, PropertyValues, query,} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, classMap, html, observer, property, PropertyValues, query} from '@material/mwc-base/base-element.js';
 import {DocumentWithBlockingElements} from 'blocking-elements';
 
 interface InertableHTMLElement extends HTMLElement {

--- a/packages/drawer/src/mwc-drawer-base.ts
+++ b/packages/drawer/src/mwc-drawer-base.ts
@@ -14,21 +14,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  BaseElement,
-  html,
-  property,
-  observer,
-  query,
-  PropertyValues,
-  classMap,
-  addHasRemoveClass,
-} from '@material/mwc-base/base-element.js';
-import MDCModalDrawerFoundation from '@material/drawer/modal/foundation.js';
-import MDCDismissibleDrawerFoundation from '@material/drawer/dismissible/foundation.js';
+import 'wicg-inert/dist/inert.js';
+
 import {MDCDrawerAdapter} from '@material/drawer/adapter.js';
 import {strings} from '@material/drawer/constants.js';
-import 'wicg-inert/dist/inert.js';
+import MDCDismissibleDrawerFoundation from '@material/drawer/dismissible/foundation.js';
+import MDCModalDrawerFoundation from '@material/drawer/modal/foundation.js';
+import {addHasRemoveClass, BaseElement, classMap, html, observer, property, PropertyValues, query,} from '@material/mwc-base/base-element.js';
 import {DocumentWithBlockingElements} from 'blocking-elements';
 
 interface InertableHTMLElement extends HTMLElement {
@@ -39,25 +31,28 @@ const blockingElements =
     (document as DocumentWithBlockingElements).$blockingElements;
 
 export class DrawerBase extends BaseElement {
-  @query('.mdc-drawer')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-drawer') protected mdcRoot!: HTMLElement;
 
-  @query('.mdc-drawer-app-content')
-  protected appContent!: InertableHTMLElement;
+  @query('.mdc-drawer-app-content') protected appContent!: InertableHTMLElement;
 
   protected mdcFoundation!: MDCDismissibleDrawerFoundation;
 
   protected get mdcFoundationClass() {
-    return this.type === 'modal' ? MDCModalDrawerFoundation : MDCDismissibleDrawerFoundation;
+    return this.type === 'modal' ? MDCModalDrawerFoundation :
+                                   MDCDismissibleDrawerFoundation;
   }
 
   protected createAdapter(): MDCDrawerAdapter {
     return {
       ...addHasRemoveClass(this.mdcRoot),
-      elementHasClass: (element: HTMLElement, className: string) => element.classList.contains(className),
+      elementHasClass: (element: HTMLElement, className: string) =>
+          element.classList.contains(className),
       saveFocus: () => {
         // Note, casting to avoid cumbersome runtime check.
-        this._previousFocus = (this.getRootNode() as any as DocumentOrShadowRoot).activeElement as HTMLElement|null;
+        this._previousFocus =
+            (this.getRootNode() as any as DocumentOrShadowRoot).activeElement as
+                HTMLElement |
+            null;
       },
       restoreFocus: () => {
         const previousFocus = this._previousFocus && this._previousFocus.focus;
@@ -67,15 +62,16 @@ export class DrawerBase extends BaseElement {
       },
       notifyClose: () => {
         this.open = false;
-        this.dispatchEvent(new Event(strings.CLOSE_EVENT, {bubbles: true, cancelable: true}));
+        this.dispatchEvent(
+            new Event(strings.CLOSE_EVENT, {bubbles: true, cancelable: true}));
       },
       notifyOpen: () => {
         this.open = true;
-        this.dispatchEvent(new Event(strings.OPEN_EVENT, {bubbles: true, cancelable: true}));
+        this.dispatchEvent(
+            new Event(strings.OPEN_EVENT, {bubbles: true, cancelable: true}));
       },
       // TODO(sorvell): Implement list focusing integration.
-      focusActiveNavigationItem: () => {
-      },
+      focusActiveNavigationItem: () => {},
       trapFocus: () => {
         blockingElements.push(this);
         this.appContent.inert = true;
@@ -108,11 +104,9 @@ export class DrawerBase extends BaseElement {
   @property({type: Boolean, reflect: true})
   open = false;
 
-  @property({type: Boolean})
-  hasHeader = false;
+  @property({type: Boolean}) hasHeader = false;
 
-  @property({reflect: true})
-  type = '';
+  @property({reflect: true}) type = '';
 
   render() {
     const dismissible = this.type === 'dismissible' || this.type === 'modal';
@@ -123,24 +117,34 @@ export class DrawerBase extends BaseElement {
         <h6 class="mdc-drawer__subtitle"><slot name="subtitle"></slot></h6>
         <slot name="header"></slot>
       </div>
-      ` : '';
+      ` :
+                                    '';
     return html`
       <aside class="mdc-drawer
-          ${classMap({'mdc-drawer--dismissible': dismissible, 'mdc-drawer--modal': modal})}">
+          ${classMap({
+      'mdc-drawer--dismissible': dismissible,
+      'mdc-drawer--modal': modal
+    })}">
         ${header}
         <div class="mdc-drawer__content"><slot></slot></div>
       </aside>
-      ${modal ? html`<div class="mdc-drawer-scrim" @click="${this._handleScrimClick}"></div>` : ''}
+      ${
+        modal ? html`<div class="mdc-drawer-scrim" @click="${
+                    this._handleScrimClick}"></div>` :
+                ''}
       <div class="mdc-drawer-app-content">
         <slot name="appContent"></slot>
       </div>
       `;
   }
 
-  // note, we avoid calling `super.firstUpdated()` to control when `createFoundation()` is called.
+  // note, we avoid calling `super.firstUpdated()` to control when
+  // `createFoundation()` is called.
   firstUpdated() {
-    this.mdcRoot.addEventListener('keydown', (e) => this.mdcFoundation.handleKeydown(e));
-    this.mdcRoot.addEventListener('transitionend', (e) => this.mdcFoundation.handleTransitionEnd(e));
+    this.mdcRoot.addEventListener(
+        'keydown', (e) => this.mdcFoundation.handleKeydown(e));
+    this.mdcRoot.addEventListener(
+        'transitionend', (e) => this.mdcFoundation.handleTransitionEnd(e));
   }
 
   updated(changedProperties: PropertyValues) {

--- a/packages/drawer/src/mwc-drawer.ts
+++ b/packages/drawer/src/mwc-drawer.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {DrawerBase} from './mwc-drawer-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
+
+import {DrawerBase} from './mwc-drawer-base.js';
 import {style} from './mwc-drawer-css.js';
 
 declare global {

--- a/packages/fab/src/mwc-fab-base.ts
+++ b/packages/fab/src/mwc-fab-base.ts
@@ -51,12 +51,10 @@ export class FabBase extends LitElement {
           aria-label="${this.label || this.icon}">
         ${showLabel && this.showIconAtEnd ? this.label : ''}
         ${
-        this.icon ?
-        html
-    `<span class="material-icons mdc-fab__icon">${this.icon}</span>`: ''}
-        ${
-        showLabel &&
-        !this.showIconAtEnd ? this.label : ''}
+        this.icon ? html`<span class="material-icons mdc-fab__icon">${
+                        this.icon}</span>` :
+                    ''}
+        ${showLabel && !this.showIconAtEnd ? this.label : ''}
       </button>`;
   }
 }

--- a/packages/fab/src/mwc-fab-base.ts
+++ b/packages/fab/src/mwc-fab-base.ts
@@ -14,30 +14,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, classMap} from '@material/mwc-base/base-element';
+import {classMap, html, LitElement, property} from '@material/mwc-base/base-element';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 
 export class FabBase extends LitElement {
-  @property({type: Boolean})
-  mini = false;
+  @property({type: Boolean}) mini = false;
 
-  @property({type: Boolean})
-  exited = false;
+  @property({type: Boolean}) exited = false;
 
-  @property({type: Boolean})
-  disabled = false;
+  @property({type: Boolean}) disabled = false;
 
-  @property({type: Boolean})
-  extended = false;
+  @property({type: Boolean}) extended = false;
 
-  @property({type: Boolean})
-  showIconAtEnd = false;
+  @property({type: Boolean}) showIconAtEnd = false;
 
-  @property()
-  icon = '';
+  @property() icon = '';
 
-  @property()
-  label = '';
+  @property() label = '';
 
   createRenderRoot() {
     return this.attachShadow({mode: 'open', delegatesFocus: true});
@@ -57,8 +50,13 @@ export class FabBase extends LitElement {
           ?disabled="${this.disabled}"
           aria-label="${this.label || this.icon}">
         ${showLabel && this.showIconAtEnd ? this.label : ''}
-        ${this.icon ? html`<span class="material-icons mdc-fab__icon">${this.icon}</span>` : ''}
-        ${showLabel && !this.showIconAtEnd ? this.label : ''}
+        ${
+        this.icon ?
+        html
+    `<span class="material-icons mdc-fab__icon">${this.icon}</span>`: ''}
+        ${
+        showLabel &&
+        !this.showIconAtEnd ? this.label : ''}
       </button>`;
   }
 }

--- a/packages/fab/src/mwc-fab.ts
+++ b/packages/fab/src/mwc-fab.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {FabBase} from './mwc-fab-base.js';
 import {customElement} from '@material/mwc-base/base-element';
+
+import {FabBase} from './mwc-fab-base.js';
 import {style} from './mwc-fab-css.js';
 
 declare global {

--- a/packages/formfield/src/mwc-formfield-base.ts
+++ b/packages/formfield/src/mwc-formfield-base.ts
@@ -14,24 +14,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  html,
-  BaseElement,
-  property,
-  query,
-  observer,
-  classMap,
-  EventType,
-  SpecificEventListener,
-} from '@material/mwc-base/base-element.js';
+import {MDCFormFieldAdapter} from '@material/form-field/adapter.js';
+import MDCFormFieldFoundation from '@material/form-field/foundation.js';
+import {BaseElement, classMap, EventType, html, observer, property, query, SpecificEventListener,} from '@material/mwc-base/base-element.js';
 import {FormElement} from '@material/mwc-base/form-element.js';
 import {findAssignedElement} from '@material/mwc-base/utils.js';
-import MDCFormFieldFoundation from '@material/form-field/foundation.js';
-import {MDCFormFieldAdapter} from '@material/form-field/adapter.js';
 
 export class FormfieldBase extends BaseElement {
-  @property({type: Boolean})
-  alignEnd = false;
+  @property({type: Boolean}) alignEnd = false;
 
   @property({type: String})
   @observer(async function(this: FormfieldBase, label: string) {
@@ -47,8 +37,7 @@ export class FormfieldBase extends BaseElement {
   })
   label = '';
 
-  @query('.mdc-form-field')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-form-field') protected mdcRoot!: HTMLElement;
 
   protected mdcFoundation!: MDCFormFieldFoundation;
 
@@ -56,12 +45,14 @@ export class FormfieldBase extends BaseElement {
 
   protected createAdapter(): MDCFormFieldAdapter {
     return {
-      registerInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) => {
-        this.labelEl.addEventListener(type, handler);
-      },
-      deregisterInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) => {
-        this.labelEl.removeEventListener(type, handler);
-      },
+      registerInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) => {
+            this.labelEl.addEventListener(type, handler);
+          },
+      deregisterInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) => {
+            this.labelEl.removeEventListener(type, handler);
+          },
       activateInputRipple: () => {
         const input = this.input;
         if (input instanceof FormElement && input.ripple) {
@@ -77,11 +68,9 @@ export class FormfieldBase extends BaseElement {
     };
   }
 
-  @query('slot')
-  protected slotEl!: HTMLSlotElement;
+  @query('slot') protected slotEl!: HTMLSlotElement;
 
-  @query('label')
-  protected labelEl!: HTMLLabelElement;
+  @query('label') protected labelEl!: HTMLLabelElement;
 
   protected get input() {
     return findAssignedElement(this.slotEl, '*');
@@ -89,9 +78,12 @@ export class FormfieldBase extends BaseElement {
 
   render() {
     return html`
-      <div class="mdc-form-field ${classMap({'mdc-form-field--align-end': this.alignEnd})}">
+      <div class="mdc-form-field ${classMap({
+      'mdc-form-field--align-end': this.alignEnd
+    })}">
         <slot></slot>
-        <label class="mdc-label" @click="${this._labelClick}">${this.label}</label>
+        <label class="mdc-label" @click="${this._labelClick}">${
+        this.label}</label>
       </div>`;
   }
 

--- a/packages/formfield/src/mwc-formfield-base.ts
+++ b/packages/formfield/src/mwc-formfield-base.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import {MDCFormFieldAdapter} from '@material/form-field/adapter.js';
 import MDCFormFieldFoundation from '@material/form-field/foundation.js';
-import {BaseElement, classMap, EventType, html, observer, property, query, SpecificEventListener,} from '@material/mwc-base/base-element.js';
+import {BaseElement, classMap, EventType, html, observer, property, query, SpecificEventListener} from '@material/mwc-base/base-element.js';
 import {FormElement} from '@material/mwc-base/form-element.js';
 import {findAssignedElement} from '@material/mwc-base/utils.js';
 

--- a/packages/formfield/src/mwc-formfield.ts
+++ b/packages/formfield/src/mwc-formfield.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {FormfieldBase} from './mwc-formfield-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
+
+import {FormfieldBase} from './mwc-formfield-base.js';
 import {style} from './mwc-formfield-css.js';
 
 declare global {

--- a/packages/icon-button/src/icon-button-base.ts
+++ b/packages/icon-button/src/icon-button-base.ts
@@ -15,9 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {BaseElement, html, property, query, observer, addHasRemoveClass} from '@material/mwc-base/base-element.js';
-import MDCIconButtonToggleFoundation from '@material/icon-button/foundation.js';
 import {MDCIconButtonToggleAdapter} from '@material/icon-button/adapter.js';
+import MDCIconButtonToggleFoundation from '@material/icon-button/foundation.js';
+import {addHasRemoveClass, BaseElement, html, observer, property, query} from '@material/mwc-base/base-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 
 export class IconButtonBase extends BaseElement {
@@ -25,20 +25,15 @@ export class IconButtonBase extends BaseElement {
 
   protected mdcFoundation!: MDCIconButtonToggleFoundation;
 
-  @query('.mdc-icon-button')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-icon-button') protected mdcRoot!: HTMLElement;
 
-  @property({type: String})
-  label = '';
+  @property({type: String}) label = '';
 
-  @property({type: Boolean, reflect: true})
-  disabled = false;
+  @property({type: Boolean, reflect: true}) disabled = false;
 
-  @property({type: String})
-  icon = '';
+  @property({type: String}) icon = '';
 
-  @property({type: String})
-  offIcon = '';
+  @property({type: String}) offIcon = '';
 
   @property({type: Boolean, reflect: true})
   @observer(function(this: IconButtonBase, state: boolean) {
@@ -56,7 +51,8 @@ export class IconButtonBase extends BaseElement {
         if (this.offIcon === '') {
           return;
         }
-        this.dispatchEvent(new CustomEvent('MDCIconButtonToggle:change', {detail: evtData, bubbles: true}));
+        this.dispatchEvent(new CustomEvent(
+            'MDCIconButtonToggle:change', {detail: evtData, bubbles: true}));
       },
     };
   }
@@ -88,7 +84,8 @@ export class IconButtonBase extends BaseElement {
         aria-label="${this.label}"
         ?disabled="${this.disabled}">
         <i class="material-icons mdc-icon-button__icon">${this.offIcon}</i>
-        <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">${this.icon}</i>
+        <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">${
+        this.icon}</i>
       </button>`;
   }
 }

--- a/packages/icon-button/src/mwc-icon-button.ts
+++ b/packages/icon-button/src/mwc-icon-button.ts
@@ -15,9 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {customElement} from '@material/mwc-base/base-element.js';
+
 import {IconButtonBase} from './icon-button-base.js';
 import {style} from './mwc-icon-button-css.js';
-import {customElement} from '@material/mwc-base/base-element.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/icon/src/mwc-icon.ts
+++ b/packages/icon/src/mwc-icon.ts
@@ -14,7 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, customElement} from '@material/mwc-base/base-element';
+import {customElement, html, LitElement} from '@material/mwc-base/base-element';
+
 import {style} from './mwc-icon-host-css.js';
 
 @customElement('mwc-icon' as any)

--- a/packages/linear-progress/src/mwc-linear-progress-base.ts
+++ b/packages/linear-progress/src/mwc-linear-progress-base.ts
@@ -14,9 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {BaseElement, html, property, observer, query, addHasRemoveClass} from '@material/mwc-base/base-element.js';
-import MDCLinearProgressFoundation from '@material/linear-progress/foundation.js';
 import {MDCLinearProgressAdapter} from '@material/linear-progress/adapter.js';
+import MDCLinearProgressFoundation from '@material/linear-progress/foundation.js';
+import {addHasRemoveClass, BaseElement, html, observer, property, query} from '@material/mwc-base/base-element.js';
 
 export class LinearProgressBase extends BaseElement {
   protected mdcFoundation!: MDCLinearProgressFoundation;
@@ -26,17 +26,16 @@ export class LinearProgressBase extends BaseElement {
   @query('.mdc-linear-progress')
   protected mdcRoot!: HTMLElement
 
-  @query('.mdc-linear-progress__primary-bar')
-  protected primaryBar!: HTMLElement
+      @query('.mdc-linear-progress__primary-bar') protected primaryBar
+      !: HTMLElement
 
-  @query('.mdc-linear-progress__buffer')
-  protected bufferElement!: HTMLElement
+      @query('.mdc-linear-progress__buffer') protected bufferElement
+      !: HTMLElement
 
-  @property({type: Boolean, reflect: true})
-  @observer(function(this: LinearProgressBase, value: boolean) {
-    this.mdcFoundation.setDeterminate(value);
-  })
-  determinate = false;
+      @property({type: Boolean, reflect: true})
+      @observer(function(this: LinearProgressBase, value: boolean) {
+        this.mdcFoundation.setDeterminate(value);
+      }) determinate = false;
 
   @property({type: Number})
   @observer(function(this: LinearProgressBase, value: number) {
@@ -86,14 +85,15 @@ export class LinearProgressBase extends BaseElement {
       getPrimaryBar: () => this.primaryBar,
       getBuffer: () => this.bufferElement,
       setStyle: (el: HTMLElement, property: string, value: string) =>
-        // TODO(aomarks) Consider moving this type to the
-        // MDCLinearProgressAdapter parameter type, but note that the
-        // "-webkit" prefixed CSS properties are not declared in
-        // CSSStyleDeclaration.
-        //
-        // Exclude read-only properties.
-        el.style[property as
-          Exclude<keyof CSSStyleDeclaration, 'length'|'parentRule'>] = value,
+          // TODO(aomarks) Consider moving this type to the
+          // MDCLinearProgressAdapter parameter type, but note that the
+          // "-webkit" prefixed CSS properties are not declared in
+          // CSSStyleDeclaration.
+          //
+          // Exclude read-only properties.
+      el.style
+          [property as
+           Exclude<keyof CSSStyleDeclaration, 'length'|'parentRule'>] = value,
     };
   }
 

--- a/packages/linear-progress/src/mwc-linear-progress-base.ts
+++ b/packages/linear-progress/src/mwc-linear-progress-base.ts
@@ -23,19 +23,18 @@ export class LinearProgressBase extends BaseElement {
 
   protected readonly mdcFoundationClass = MDCLinearProgressFoundation;
 
-  @query('.mdc-linear-progress')
-  protected mdcRoot!: HTMLElement
+  @query('.mdc-linear-progress') protected mdcRoot!: HTMLElement;
 
-      @query('.mdc-linear-progress__primary-bar') protected primaryBar
-      !: HTMLElement
+  @query('.mdc-linear-progress__primary-bar')
+  protected primaryBar!: HTMLElement;
 
-      @query('.mdc-linear-progress__buffer') protected bufferElement
-      !: HTMLElement
+  @query('.mdc-linear-progress__buffer') protected bufferElement!: HTMLElement;
 
-      @property({type: Boolean, reflect: true})
-      @observer(function(this: LinearProgressBase, value: boolean) {
-        this.mdcFoundation.setDeterminate(value);
-      }) determinate = false;
+  @property({type: Boolean, reflect: true})
+  @observer(function(this: LinearProgressBase, value: boolean) {
+    this.mdcFoundation.setDeterminate(value);
+  })
+  determinate = false;
 
   @property({type: Number})
   @observer(function(this: LinearProgressBase, value: number) {
@@ -84,16 +83,15 @@ export class LinearProgressBase extends BaseElement {
       ...addHasRemoveClass(this.mdcRoot),
       getPrimaryBar: () => this.primaryBar,
       getBuffer: () => this.bufferElement,
-      setStyle: (el: HTMLElement, property: string, value: string) =>
-          // TODO(aomarks) Consider moving this type to the
-          // MDCLinearProgressAdapter parameter type, but note that the
-          // "-webkit" prefixed CSS properties are not declared in
-          // CSSStyleDeclaration.
-          //
-          // Exclude read-only properties.
-      el.style
-          [property as
-           Exclude<keyof CSSStyleDeclaration, 'length'|'parentRule'>] = value,
+      setStyle: (el: HTMLElement, property: string, value: string) => {
+        // TODO(aomarks) Consider moving this type to the
+        // MDCLinearProgressAdapter parameter type, but note that the "-webkit"
+        // prefixed CSS properties are not declared in CSSStyleDeclaration.
+        //
+        // Exclude read-only properties.
+        el.style[property as Exclude<keyof CSSStyleDeclaration, 'length'|'parentRule'>] =
+            value;
+      },
     };
   }
 

--- a/packages/linear-progress/src/mwc-linear-progress.ts
+++ b/packages/linear-progress/src/mwc-linear-progress.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LinearProgressBase} from './mwc-linear-progress-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
+
+import {LinearProgressBase} from './mwc-linear-progress-base.js';
 import {style} from './mwc-linear-progress-css.js';
 
 declare global {

--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query,} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import {MDCRadioAdapter} from '@material/radio/adapter.js';
 import MDCRadioFoundation from '@material/radio/foundation.js';

--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -14,31 +14,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  FormElement,
-  query,
-  property,
-  html,
-  observer,
-  HTMLElementWithRipple,
-  addHasRemoveClass,
-} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query,} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
-import MDCRadioFoundation from '@material/radio/foundation.js';
 import {MDCRadioAdapter} from '@material/radio/adapter.js';
+import MDCRadioFoundation from '@material/radio/foundation.js';
 
 export class RadioBase extends FormElement {
-  @query('.mdc-radio')
-  protected mdcRoot!: HTMLElementWithRipple;
+  @query('.mdc-radio') protected mdcRoot!: HTMLElementWithRipple;
 
   @query('input')
   protected formElement!: HTMLInputElement
 
-  @property({type: Boolean})
-  @observer(function(this: RadioBase, checked: boolean) {
-    this.formElement.checked = checked;
-  })
-  checked = false;
+      @property({type: Boolean})
+      @observer(function(this: RadioBase, checked: boolean) {
+        this.formElement.checked = checked;
+      }) checked = false;
 
   @property({type: Boolean})
   @observer(function(this: RadioBase, disabled: boolean) {
@@ -52,14 +42,13 @@ export class RadioBase extends FormElement {
   })
   value = '';
 
-  @property({type: String})
-  name = '';
+  @property({type: String}) name = '';
 
   protected mdcFoundationClass = MDCRadioFoundation;
 
   protected mdcFoundation!: MDCRadioFoundation;
 
-  private _selectionController: SelectionController | null = null;
+  private _selectionController: SelectionController|null = null;
 
   constructor() {
     super();
@@ -150,15 +139,15 @@ export class RadioBase extends FormElement {
 const selectionController = Symbol('selection controller');
 
 class SelectionSet {
-  selected: RadioBase | null = null;
-  ordered: RadioBase[] | null = null;
+  selected: RadioBase|null = null;
+  ordered: RadioBase[]|null = null;
   readonly set = new Set<RadioBase>();
 }
 
 export class SelectionController {
   private sets: {[name: string]: SelectionSet} = {};
 
-  private focusedSet: SelectionSet | null = null;
+  private focusedSet: SelectionSet|null = null;
 
   private mouseIsDown = false;
 
@@ -174,7 +163,8 @@ export class SelectionController {
   }
 
   constructor(element: Node) {
-    element.addEventListener('keydown', (e: Event) => this.keyDownHandler(e as KeyboardEvent));
+    element.addEventListener(
+        'keydown', (e: Event) => this.keyDownHandler(e as KeyboardEvent));
     element.addEventListener('mousedown', () => this.mousedownHandler());
     element.addEventListener('mouseup', () => this.mouseupHandler());
   }
@@ -210,13 +200,13 @@ export class SelectionController {
   previous(element: RadioBase) {
     const order = this.getOrdered(element);
     const i = order.indexOf(element);
-    this.select(order[i-1] || order[order.length-1]);
+    this.select(order[i - 1] || order[order.length - 1]);
   }
 
   next(element: RadioBase) {
     const order = this.getOrdered(element);
     const i = order.indexOf(element);
-    this.select(order[i+1] || order[0]);
+    this.select(order[i + 1] || order[0]);
   }
 
   select(element: RadioBase) {
@@ -244,9 +234,11 @@ export class SelectionController {
     const set = this.getSet(element.name);
     if (!set.ordered) {
       set.ordered = Array.from(set.set);
-      set.ordered.sort((a, b) =>
-        a.compareDocumentPosition(b) == Node.DOCUMENT_POSITION_PRECEDING ? 1 : 0
-      );
+      set.ordered.sort(
+          (a, b) =>
+              a.compareDocumentPosition(b) == Node.DOCUMENT_POSITION_PRECEDING ?
+              1 :
+              0);
     }
     return set.ordered;
   }

--- a/packages/radio/src/mwc-radio.ts
+++ b/packages/radio/src/mwc-radio.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {RadioBase} from './mwc-radio-base.js';
 import {customElement} from '@material/mwc-base/form-element.js';
+
+import {RadioBase} from './mwc-radio-base.js';
 import {style} from './mwc-radio-css.js';
 
 declare global {

--- a/packages/ripple/src/mwc-ripple-base.ts
+++ b/packages/ripple/src/mwc-ripple-base.ts
@@ -14,27 +14,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, property, classMap} from '@material/mwc-base/base-element';
+import {classMap, html, LitElement, property} from '@material/mwc-base/base-element';
+
 import {ripple, RippleOptions} from './ripple-directive.js';
 
 export class RippleBase extends LitElement {
-  @property({type: Boolean})
-  primary = false;
+  @property({type: Boolean}) primary = false;
 
-  @property({type: Boolean})
-  active: boolean|undefined;
+  @property({type: Boolean}) active: boolean|undefined;
 
-  @property({type: Boolean})
-  accent = false;
+  @property({type: Boolean}) accent = false;
 
-  @property({type: Boolean})
-  unbounded = false;
+  @property({type: Boolean}) unbounded = false;
 
-  @property({type: Boolean})
-  disabled = false;
+  @property({type: Boolean}) disabled = false;
 
-  @property()
-  protected interactionNode: HTMLElement = this;
+  @property() protected interactionNode: HTMLElement = this;
 
   connectedCallback() {
     if (this.interactionNode === this) {

--- a/packages/ripple/src/mwc-ripple.ts
+++ b/packages/ripple/src/mwc-ripple.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {RippleBase} from './mwc-ripple-base.js';
 import {customElement} from '@material/mwc-base/base-element';
+
+import {RippleBase} from './mwc-ripple-base.js';
 import {style} from './mwc-ripple-css.js';
 
 declare global {

--- a/packages/ripple/src/ripple-directive.ts
+++ b/packages/ripple/src/ripple-directive.ts
@@ -14,15 +14,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {directive, PropertyPart, noChange, NodePart, templateFactory} from 'lit-html';
-import MDCRippleFoundation from '@material/ripple/foundation.js';
-import {MDCRippleAdapter} from '@material/ripple/adapter.js';
-import {style} from './mwc-ripple-global-css.js';
-import {supportsCssVariables} from '@material/ripple/util.js';
 import {applyPassive} from '@material/dom/events';
 import {matches} from '@material/dom/ponyfill';
-
 import {EventType, SpecificEventListener} from '@material/mwc-base/base-element.js';
+import {MDCRippleAdapter} from '@material/ripple/adapter.js';
+import MDCRippleFoundation from '@material/ripple/foundation.js';
+import {supportsCssVariables} from '@material/ripple/util.js';
+import {directive, noChange, NodePart, PropertyPart, templateFactory} from 'lit-html';
+
+import {style} from './mwc-ripple-global-css.js';
 
 const supportsCssVariablesWin = supportsCssVariables(window);
 
@@ -45,9 +45,10 @@ declare global {
   }
 }
 
-// NOTE: This is a workaround for https://bugs.webkit.org/show_bug.cgi?id=173027.
-// Since keyframes on pseudo-elements (:after) are not supported in Shadow DOM,
-// we put the keyframe style into the <head> element.
+// NOTE: This is a workaround for
+// https://bugs.webkit.org/show_bug.cgi?id=173027. Since keyframes on
+// pseudo-elements (:after) are not supported in Shadow DOM, we put the keyframe
+// style into the <head> element.
 const isSafari = navigator.userAgent.match(/Safari/);
 let didApplyRippleStyle = false;
 const applyRippleStyle = () => {
@@ -66,9 +67,9 @@ export const rippleNode = (options: RippleNodeOptions) => {
   if (isSafari && !didApplyRippleStyle) {
     applyRippleStyle();
   }
-  // TODO(sorvell): This directive requires bringing css yourself. We probably need to do this
-  // because of ShadyCSS, but on Safari, the keyframes styling must be global. Perhaps this
-  // directive could fix that.
+  // TODO(sorvell): This directive requires bringing css yourself. We probably
+  // need to do this because of ShadyCSS, but on Safari, the keyframes styling
+  // must be global. Perhaps this directive could fix that.
   const surfaceNode = options.surfaceNode;
   const interactionNode = options.interactionNode || surfaceNode;
   // only style interaction node if not in the same root
@@ -80,29 +81,35 @@ export const rippleNode = (options: RippleNodeOptions) => {
   const adapter: MDCRippleAdapter = {
     browserSupportsCssVars: () => supportsCssVariablesWin,
     isUnbounded: () =>
-      options.unbounded === undefined ? true : options.unbounded,
+        options.unbounded === undefined ? true : options.unbounded,
     isSurfaceActive: () => matches(interactionNode, ':active'),
     isSurfaceDisabled: () => Boolean(options.disabled),
     addClass: (className: string) => surfaceNode.classList.add(className),
-    removeClass: (className: string) =>
-      surfaceNode.classList.remove(className),
-    containsEventTarget: (target: HTMLElement) => interactionNode.contains(target),
-    registerInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-      interactionNode.addEventListener(type, handler, applyPassive()),
-    deregisterInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-      interactionNode.removeEventListener(type, handler, applyPassive()),
-    registerDocumentInteractionHandler: <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
-      document.documentElement!.addEventListener(
-        evtType, handler, applyPassive()),
-    deregisterDocumentInteractionHandler: <K extends EventType>(evtType: string, handler: SpecificEventListener<K>) =>
-      document.documentElement!.removeEventListener(
-        evtType, handler as EventListenerOrEventListenerObject, applyPassive()),
+    removeClass: (className: string) => surfaceNode.classList.remove(className),
+    containsEventTarget: (target: HTMLElement) =>
+        interactionNode.contains(target),
+    registerInteractionHandler:
+        <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+            interactionNode.addEventListener(type, handler, applyPassive()),
+    deregisterInteractionHandler:
+        <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+            interactionNode.removeEventListener(type, handler, applyPassive()),
+    registerDocumentInteractionHandler:
+        <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
+            document.documentElement!.addEventListener(
+                evtType, handler, applyPassive()),
+    deregisterDocumentInteractionHandler: <K extends EventType>(
+        evtType: string, handler: SpecificEventListener<K>) =>
+        document.documentElement!.removeEventListener(
+            evtType,
+            handler as EventListenerOrEventListenerObject,
+            applyPassive()),
     registerResizeHandler: (handler: SpecificEventListener<'resize'>) =>
-      window.addEventListener('resize', handler),
+        window.addEventListener('resize', handler),
     deregisterResizeHandler: (handler: SpecificEventListener<'resize'>) =>
-      window.removeEventListener('resize', handler),
+        window.removeEventListener('resize', handler),
     updateCssVariable: (varName: string, value: string) =>
-      surfaceNode.style.setProperty(varName, value),
+        surfaceNode.style.setProperty(varName, value),
     computeBoundingRect: () => surfaceNode.getBoundingClientRect(),
     getWindowPageOffset: () => ({x: window.pageXOffset, y: window.pageYOffset}),
   };
@@ -118,33 +125,37 @@ const rippleInteractionNodes = new WeakMap();
  * should be applied to a PropertyPart.
  * @param options {RippleOptions}
  */
-export const ripple = directive((options: RippleOptions = {}) => (part: PropertyPart) => {
-  const surfaceNode = part.committer.element as HTMLElement;
-  const interactionNode = options.interactionNode || surfaceNode;
-  let rippleFoundation = (part.value as any);
-  // if the interaction node changes, destroy and invalidate the foundation.
-  const existingInteractionNode = rippleInteractionNodes.get(rippleFoundation);
-  if (existingInteractionNode !== undefined && existingInteractionNode !== interactionNode) {
-    rippleFoundation.destroy();
-    rippleFoundation = noChange;
-  }
-  // make the ripple, if needed
-  if (rippleFoundation === noChange) {
-    rippleFoundation = rippleNode(Object.assign({}, options, {surfaceNode}));
-    rippleInteractionNodes.set(rippleFoundation, interactionNode);
-    part.setValue(rippleFoundation);
-  // otherwise update settings as needed.
-  } else {
-    if (options.unbounded !== undefined) {
-      rippleFoundation.setUnbounded(options.unbounded);
-    }
-    if (options.disabled !== undefined) {
-      rippleFoundation.setUnbounded(options.disabled);
-    }
-  }
-  if (options.active === true) {
-    rippleFoundation.activate();
-  } else if (options.active === false) {
-    rippleFoundation.deactivate();
-  }
-});
+export const ripple =
+    directive((options: RippleOptions = {}) => (part: PropertyPart) => {
+      const surfaceNode = part.committer.element as HTMLElement;
+      const interactionNode = options.interactionNode || surfaceNode;
+      let rippleFoundation = (part.value as any);
+      // if the interaction node changes, destroy and invalidate the foundation.
+      const existingInteractionNode =
+          rippleInteractionNodes.get(rippleFoundation);
+      if (existingInteractionNode !== undefined &&
+          existingInteractionNode !== interactionNode) {
+        rippleFoundation.destroy();
+        rippleFoundation = noChange;
+      }
+      // make the ripple, if needed
+      if (rippleFoundation === noChange) {
+        rippleFoundation =
+            rippleNode(Object.assign({}, options, {surfaceNode}));
+        rippleInteractionNodes.set(rippleFoundation, interactionNode);
+        part.setValue(rippleFoundation);
+        // otherwise update settings as needed.
+      } else {
+        if (options.unbounded !== undefined) {
+          rippleFoundation.setUnbounded(options.unbounded);
+        }
+        if (options.disabled !== undefined) {
+          rippleFoundation.setUnbounded(options.disabled);
+        }
+      }
+      if (options.active === true) {
+        rippleFoundation.activate();
+      } else if (options.active === false) {
+        rippleFoundation.deactivate();
+      }
+    });

--- a/packages/slider/src/mwc-slider-base.ts
+++ b/packages/slider/src/mwc-slider-base.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, classMap, EventType, FormElement, html, observer, property, query, SpecificEventListener,} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, classMap, EventType, FormElement, html, observer, property, query, SpecificEventListener} from '@material/mwc-base/form-element.js';
 import {MDCSliderAdapter} from '@material/slider/adapter.js';
 import MDCSliderFoundation from '@material/slider/foundation.js';
 import {repeat} from 'lit-html/directives/repeat.js';

--- a/packages/slider/src/mwc-slider-base.ts
+++ b/packages/slider/src/mwc-slider-base.ts
@@ -97,22 +97,21 @@ export class SliderBase extends FormElement {
         <div class="mdc-slider__track"></div>
         ${
         discrete && markers ?
-        html
-    `<div class="mdc-slider__track-marker-container">
+            html`<div class="mdc-slider__track-marker-container">
           ${
-        repeat(
-            new Array(_numMarkers),
-            () => html`<div class="mdc-slider__track-marker"></div>`)}
-        </div>`: ''}
+                repeat(
+                    new Array(_numMarkers),
+                    () => html`<div class="mdc-slider__track-marker"></div>`)}
+        </div>` :
+            ''}
       </div>
       <div class="mdc-slider__thumb-container">
         <!-- TODO: use cache() directive -->
         ${
-        discrete ?
-        html`<div class="mdc-slider__pin">
+        discrete ? html`<div class="mdc-slider__pin">
           <span class="mdc-slider__pin-value-marker"></span>
         </div>` :
-        ''}
+                   ''}
         <svg class="mdc-slider__thumb" width="21" height="21">
           <circle cx="10.5" cy="10.5" r="7.875"></circle>
         </svg>

--- a/packages/slider/src/mwc-slider-base.ts
+++ b/packages/slider/src/mwc-slider-base.ts
@@ -14,20 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  FormElement,
-  html,
-  property,
-  observer,
-  query,
-  classMap,
-  SpecificEventListener,
-  addHasRemoveClass,
-  EventType,
-} from '@material/mwc-base/form-element.js';
-import {repeat} from 'lit-html/directives/repeat.js';
-import MDCSliderFoundation from '@material/slider/foundation.js';
+import {addHasRemoveClass, classMap, EventType, FormElement, html, observer, property, query, SpecificEventListener,} from '@material/mwc-base/form-element.js';
 import {MDCSliderAdapter} from '@material/slider/adapter.js';
+import MDCSliderFoundation from '@material/slider/foundation.js';
+import {repeat} from 'lit-html/directives/repeat.js';
 
 const {INPUT_EVENT, CHANGE_EVENT} = MDCSliderFoundation.strings;
 
@@ -39,17 +29,13 @@ export class SliderBase extends FormElement {
   @query('.mdc-slider')
   protected mdcRoot!: HTMLElement
 
-  @query('.mdc-slider')
-  protected formElement!: HTMLElement;
+      @query('.mdc-slider') protected formElement!: HTMLElement;
 
-  @query('.mdc-slider__thumb-container')
-  protected thumbContainer!: HTMLElement;
+  @query('.mdc-slider__thumb-container') protected thumbContainer!: HTMLElement;
 
-  @query('.mdc-slider__track')
-  protected trackElement!: HTMLElement;
+  @query('.mdc-slider__track') protected trackElement!: HTMLElement;
 
-  @query('.mdc-slider__pin-value-marker')
-  protected pinMarker!: HTMLElement;
+  @query('.mdc-slider__pin-value-marker') protected pinMarker!: HTMLElement;
 
   @query('.mdc-slider__track-marker-container')
   protected trackMarkerContainer!: HTMLElement;
@@ -84,8 +70,7 @@ export class SliderBase extends FormElement {
   })
   disabled = false;
 
-  @property({type: Boolean, reflect: true})
-  discrete = false;
+  @property({type: Boolean, reflect: true}) discrete = false;
 
   @property({type: Boolean, reflect: true})
   @observer(function(this: SliderBase) {
@@ -93,31 +78,41 @@ export class SliderBase extends FormElement {
   })
   markers = false;
 
-  @property({type: Number})
-  private _numMarkers = 0;
+  @property({type: Number}) private _numMarkers = 0;
 
   // TODO(sorvell) #css: needs a default width
   render() {
-    const {value, min, max, step, disabled, discrete, markers, _numMarkers} = this;
+    const {value, min, max, step, disabled, discrete, markers, _numMarkers} =
+        this;
     const hostClassInfo = {
       'mdc-slider--discrete': discrete,
       'mdc-slider--display-markers': markers && discrete,
     };
     return html`
-      <div class="mdc-slider ${classMap(hostClassInfo)}" tabindex="0" role="slider"
+      <div class="mdc-slider ${
+        classMap(hostClassInfo)}" tabindex="0" role="slider"
         aria-valuemin="${min}" aria-valuemax="${max}" aria-valuenow="${value}"
         aria-disabled="${disabled}" data-step="${step}">
       <div class="mdc-slider__track-container">
         <div class="mdc-slider__track"></div>
-        ${discrete && markers ? html`<div class="mdc-slider__track-marker-container">
-          ${repeat(new Array(_numMarkers), () => html`<div class="mdc-slider__track-marker"></div>`)}
-        </div>` : ''}
+        ${
+        discrete && markers ?
+        html
+    `<div class="mdc-slider__track-marker-container">
+          ${
+        repeat(
+            new Array(_numMarkers),
+            () => html`<div class="mdc-slider__track-marker"></div>`)}
+        </div>`: ''}
       </div>
       <div class="mdc-slider__thumb-container">
         <!-- TODO: use cache() directive -->
-        ${discrete ? html`<div class="mdc-slider__pin">
+        ${
+        discrete ?
+        html`<div class="mdc-slider__pin">
           <span class="mdc-slider__pin-value-marker"></span>
-        </div>` : ''}
+        </div>` :
+        ''}
         <svg class="mdc-slider__thumb" width="21" height="21">
           <circle cx="10.5" cy="10.5" r="7.875"></circle>
         </svg>
@@ -130,47 +125,59 @@ export class SliderBase extends FormElement {
     return {
       ...addHasRemoveClass(this.mdcRoot),
       getAttribute: (name: string) => this.mdcRoot.getAttribute(name),
-      setAttribute: (name: string, value: string) => this.mdcRoot.setAttribute(name, value),
+      setAttribute: (name: string, value: string) =>
+          this.mdcRoot.setAttribute(name, value),
       removeAttribute: (name: string) => this.mdcRoot.removeAttribute(name),
       computeBoundingRect: () => this.mdcRoot.getBoundingClientRect(),
       getTabIndex: () => this.mdcRoot.tabIndex,
-      registerInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-        this.mdcRoot.addEventListener(type, handler),
-      deregisterInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-        this.mdcRoot.removeEventListener(type, handler),
-      registerThumbContainerInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-        this.thumbContainer.addEventListener(type, handler),
-      deregisterThumbContainerInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-        this.thumbContainer.removeEventListener(type, handler),
-      registerBodyInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-        document.body.addEventListener(type, handler),
-      deregisterBodyInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-        document.body.removeEventListener(type, handler),
+      registerInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              this.mdcRoot.addEventListener(type, handler),
+      deregisterInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              this.mdcRoot.removeEventListener(type, handler),
+      registerThumbContainerInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              this.thumbContainer.addEventListener(type, handler),
+      deregisterThumbContainerInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              this.thumbContainer.removeEventListener(type, handler),
+      registerBodyInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              document.body.addEventListener(type, handler),
+      deregisterBodyInteractionHandler:
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              document.body.removeEventListener(type, handler),
       registerResizeHandler: (handler: SpecificEventListener<'resize'>) =>
-        window.addEventListener('resize', handler),
+          window.addEventListener('resize', handler),
       deregisterResizeHandler: (handler: SpecificEventListener<'resize'>) =>
-        window.removeEventListener('resize', handler),
+          window.removeEventListener('resize', handler),
       notifyInput: () => {
         const value = this.mdcFoundation.getValue();
         if (value !== this.value) {
           this.value = value;
-          this.dispatchEvent(new CustomEvent(INPUT_EVENT, {detail: this, bubbles: true, cancelable: true}));
+          this.dispatchEvent(new CustomEvent(
+              INPUT_EVENT, {detail: this, bubbles: true, cancelable: true}));
         }
       },
       notifyChange: () => {
-        this.dispatchEvent(new CustomEvent(CHANGE_EVENT, {detail: this, bubbles: true, cancelable: true}));
+        this.dispatchEvent(new CustomEvent(
+            CHANGE_EVENT, {detail: this, bubbles: true, cancelable: true}));
       },
       setThumbContainerStyleProperty: (propertyName: string, value: string) =>
-        this.thumbContainer.style.setProperty(propertyName, value),
+          this.thumbContainer.style.setProperty(propertyName, value),
       setTrackStyleProperty: (propertyName: string, value: string) =>
-        this.trackElement.style.setProperty(propertyName, value),
-      setMarkerValue: (value: number) => this.pinMarker.innerText = value.toString(),
+          this.trackElement.style.setProperty(propertyName, value),
+      setMarkerValue: (value: number) => this.pinMarker.innerText =
+          value.toString(),
       appendTrackMarkers: (numMarkers: number) => this._numMarkers = numMarkers,
       removeTrackMarkers: () => {},
       setLastTrackMarkersStyleProperty: (propertyName: string, value: string) =>
-        // We remove and append new nodes, thus, the last track marker must be dynamically found.
-        (this.mdcRoot.querySelector('.mdc-slider__track-marker:last-child') as HTMLElement).
-          style.setProperty(propertyName, value),
+          // We remove and append new nodes, thus, the last track marker must be
+          // dynamically found.
+      (this.mdcRoot.querySelector('.mdc-slider__track-marker:last-child') as
+       HTMLElement)
+          .style.setProperty(propertyName, value),
       isRTL: () => getComputedStyle(this.mdcRoot).direction === 'rtl',
     };
   }

--- a/packages/slider/src/mwc-slider.ts
+++ b/packages/slider/src/mwc-slider.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {SliderBase} from './mwc-slider-base.js';
 import {customElement} from '@material/mwc-base/form-element.js';
+
+import {SliderBase} from './mwc-slider-base.js';
 import {style} from './mwc-slider-css.js';
 
 declare global {
@@ -26,5 +27,5 @@ declare global {
 
 @customElement('mwc-slider' as any)
 export class Slider extends SliderBase {
- static styles = style;
+  static styles = style;
 }

--- a/packages/snackbar/src/mwc-snackbar-base.ts
+++ b/packages/snackbar/src/mwc-snackbar-base.ts
@@ -14,21 +14,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  BaseElement,
-  html,
-  property,
-  query,
-  observer,
-  classMap,
-  addHasRemoveClass,
-} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, classMap, html, observer, property, query,} from '@material/mwc-base/base-element.js';
+import {MDCSnackbarAdapter} from '@material/snackbar/adapter.js';
 import MDCSnackbarFoundation from '@material/snackbar/foundation.js';
 import {MDCSnackbarCloseEventDetail} from '@material/snackbar/types';
 import * as util from '@material/snackbar/util';
-import {MDCSnackbarAdapter} from '@material/snackbar/adapter.js';
 
-const {OPENING_EVENT, OPENED_EVENT, CLOSING_EVENT, CLOSED_EVENT} = MDCSnackbarFoundation.strings;
+const {OPENING_EVENT, OPENED_EVENT, CLOSING_EVENT, CLOSED_EVENT} =
+    MDCSnackbarFoundation.strings;
 
 export class SnackbarBase extends BaseElement {
   protected mdcFoundation!: MDCSnackbarFoundation;
@@ -38,11 +31,9 @@ export class SnackbarBase extends BaseElement {
   @query('.mdc-snackbar')
   protected mdcRoot!: HTMLElement
 
-  @query('.mdc-snackbar__label')
-  protected labelElement!: HTMLElement
+      @query('.mdc-snackbar__label') protected labelElement!: HTMLElement
 
-  @property({type: Boolean, reflect: true})
-  isOpen = false;
+      @property({type: Boolean, reflect: true}) isOpen = false;
 
   @observer(function(this: SnackbarBase, value: number) {
     this.mdcFoundation.setTimeoutMs(value);
@@ -56,14 +47,11 @@ export class SnackbarBase extends BaseElement {
   @property({type: Boolean})
   closeOnEscape = false;
 
-  @property()
-  labelText = '';
+  @property() labelText = '';
 
-  @property({type: Boolean})
-  stacked = false;
+  @property({type: Boolean}) stacked = false;
 
-  @property({type: Boolean})
-  leading = false;
+  @property({type: Boolean}) leading = false;
 
   render() {
     const classes = {
@@ -71,7 +59,8 @@ export class SnackbarBase extends BaseElement {
       'mdc-snackbar--leading': this.leading,
     };
     return html`
-      <div class="mdc-snackbar ${classMap(classes)}" @keydown="${this._handleKeydown}">
+      <div class="mdc-snackbar ${classMap(classes)}" @keydown="${
+        this._handleKeydown}">
         <div class="mdc-snackbar__surface">
           <div class="mdc-snackbar__label"
                role="status"
@@ -92,16 +81,29 @@ export class SnackbarBase extends BaseElement {
       announce: () => util.announce(this.labelElement),
       notifyClosed: (reason: String) => {
         this.isOpen = false;
-        this.dispatchEvent(new CustomEvent(CLOSED_EVENT,
-          {bubbles: true, cancelable: true, detail: <MDCSnackbarCloseEventDetail>{reason: reason}}));
+        this.dispatchEvent(new CustomEvent(CLOSED_EVENT, {
+          bubbles: true,
+          cancelable: true,
+          detail: <MDCSnackbarCloseEventDetail> {
+            reason: reason
+          }
+        }));
       },
-      notifyClosing: (reason: String) => this.dispatchEvent(new CustomEvent(CLOSING_EVENT,
-        {bubbles: true, cancelable: true, detail: <MDCSnackbarCloseEventDetail>{reason: reason}})),
+      notifyClosing: (reason: String) =>
+          this.dispatchEvent(new CustomEvent(CLOSING_EVENT, {
+            bubbles: true,
+            cancelable: true,
+            detail: <MDCSnackbarCloseEventDetail> {
+              reason: reason
+            }
+          })),
       notifyOpened: () => {
         this.isOpen = true;
-        this.dispatchEvent(new CustomEvent(OPENED_EVENT, {bubbles: true, cancelable: true}));
+        this.dispatchEvent(
+            new CustomEvent(OPENED_EVENT, {bubbles: true, cancelable: true}));
       },
-      notifyOpening: () => this.dispatchEvent(new CustomEvent(OPENING_EVENT, {bubbles: true, cancelable: true})),
+      notifyOpening: () => this.dispatchEvent(
+          new CustomEvent(OPENING_EVENT, {bubbles: true, cancelable: true})),
     };
   }
 
@@ -110,7 +112,7 @@ export class SnackbarBase extends BaseElement {
   }
 
   close(reason = '') {
-    this.mdcFoundation. close(reason);
+    this.mdcFoundation.close(reason);
   }
 
   _handleKeydown(e: KeyboardEvent) {

--- a/packages/snackbar/src/mwc-snackbar-base.ts
+++ b/packages/snackbar/src/mwc-snackbar-base.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, BaseElement, classMap, html, observer, property, query,} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, classMap, html, observer, property, query} from '@material/mwc-base/base-element.js';
 import {MDCSnackbarAdapter} from '@material/snackbar/adapter.js';
 import MDCSnackbarFoundation from '@material/snackbar/foundation.js';
 import {MDCSnackbarCloseEventDetail} from '@material/snackbar/types';

--- a/packages/snackbar/src/mwc-snackbar.ts
+++ b/packages/snackbar/src/mwc-snackbar.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {SnackbarBase} from './mwc-snackbar-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
+
+import {SnackbarBase} from './mwc-snackbar-base.js';
 import {style} from './mwc-snackbar-css.js';
 
 declare global {

--- a/packages/switch/src/mwc-switch-base.ts
+++ b/packages/switch/src/mwc-switch-base.ts
@@ -14,18 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  FormElement,
-  html,
-  property,
-  observer,
-  query,
-  HTMLElementWithRipple,
-  addHasRemoveClass,
-} from '@material/mwc-base/form-element.js';
-import MDCSwitchFoundation from '@material/switch/foundation.js';
+import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query,} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import {MDCSwitchAdapter} from '@material/switch/adapter';
+import MDCSwitchFoundation from '@material/switch/foundation.js';
 
 export class SwitchBase extends FormElement {
   @property({type: Boolean})
@@ -40,11 +32,9 @@ export class SwitchBase extends FormElement {
   })
   disabled = false;
 
-  @query('.mdc-switch')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-switch') protected mdcRoot!: HTMLElement;
 
-  @query('input')
-  protected formElement!: HTMLInputElement;
+  @query('input') protected formElement!: HTMLInputElement;
 
   protected mdcFoundation!: MDCSwitchFoundation;
 
@@ -79,7 +69,9 @@ export class SwitchBase extends FormElement {
     return html`
       <div class="mdc-switch">
         <div class="mdc-switch__track"></div>
-        <div class="mdc-switch__thumb-underlay" .ripple="${ripple({interactionNode: this})}">
+        <div class="mdc-switch__thumb-underlay" .ripple="${ripple({
+      interactionNode: this
+    })}">
           <div class="mdc-switch__thumb">
             <input
               type="checkbox"

--- a/packages/switch/src/mwc-switch-base.ts
+++ b/packages/switch/src/mwc-switch-base.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query,} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import {MDCSwitchAdapter} from '@material/switch/adapter';
 import MDCSwitchFoundation from '@material/switch/foundation.js';

--- a/packages/switch/src/mwc-switch.ts
+++ b/packages/switch/src/mwc-switch.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {SwitchBase} from './mwc-switch-base.js';
 import {customElement} from '@material/mwc-base/form-element.js';
+
+import {SwitchBase} from './mwc-switch-base.js';
 import {style} from './mwc-switch-css.js';
 
 declare global {

--- a/packages/tab-bar/src/mwc-tab-bar-base.ts
+++ b/packages/tab-bar/src/mwc-tab-bar-base.ts
@@ -14,22 +14,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  BaseElement,
-  html,
-  property,
-  observer,
-  query,
-} from '@material/mwc-base/base-element.js';
-import {Tab} from '@material/mwc-tab';
-import {TabScroller} from '@material/mwc-tab-scroller';
-
 // Make TypeScript not remove the imports.
 import '@material/mwc-tab';
 import '@material/mwc-tab-scroller';
 
-import MDCTabBarFoundation from '@material/tab-bar/foundation';
+import {BaseElement, html, observer, property, query,} from '@material/mwc-base/base-element.js';
+import {Tab} from '@material/mwc-tab';
+import {TabScroller} from '@material/mwc-tab-scroller';
 import {MDCTabBarAdapter} from '@material/tab-bar/adapter';
+import MDCTabBarFoundation from '@material/tab-bar/foundation';
 import {MDCTabInteractionEvent} from '@material/tab/types';
 
 export class TabBarBase extends BaseElement {
@@ -40,22 +33,18 @@ export class TabBarBase extends BaseElement {
   @query('.mdc-tab-bar')
   protected mdcRoot!: HTMLElement
 
-  @query('mwc-tab-scroller')
-  protected scrollerElement!: TabScroller
+      @query('mwc-tab-scroller') protected scrollerElement!: TabScroller
 
-  @query('slot')
-  protected tabsSlot!: HTMLSlotElement
+      @query('slot') protected tabsSlot!: HTMLSlotElement
 
-  @observer(async function(this: TabBarBase, value: number) {
-    await this.updateComplete;
-    // only provoke the foundation if we are out of sync with it, i.e.
-    // ignore an foundation generated set.
-    if (value !== this._previousActiveIndex) {
-      this.mdcFoundation.activateTab(value);
-    }
-  })
-  @property({type: Number})
-  activeIndex = 0;
+      @observer(async function(this: TabBarBase, value: number) {
+        await this.updateComplete;
+        // only provoke the foundation if we are out of sync with it, i.e.
+        // ignore an foundation generated set.
+        if (value !== this._previousActiveIndex) {
+          this.mdcFoundation.activateTab(value);
+        }
+      }) @property({type: Number}) activeIndex = 0;
 
   private _previousActiveIndex = -1;
 
@@ -80,7 +69,8 @@ export class TabBarBase extends BaseElement {
 
   // TODO(sorvell): probably want to memoize this and use a `slotChange` event
   private _getTabs() {
-    return this.tabsSlot.assignedNodes({flatten: true}).filter((e: Node) => e instanceof Tab) as Tab[];
+    return this.tabsSlot.assignedNodes({flatten: true})
+               .filter((e: Node) => e instanceof Tab) as Tab[];
   }
 
   private _getTab(index: number) {
@@ -89,12 +79,15 @@ export class TabBarBase extends BaseElement {
 
   createAdapter(): MDCTabBarAdapter {
     return {
-      scrollTo: (scrollX: number) => this.scrollerElement.scrollToPosition(scrollX),
-      incrementScroll: (scrollXIncrement: number) => this.scrollerElement.incrementScrollPosition(scrollXIncrement),
+      scrollTo: (scrollX: number) =>
+          this.scrollerElement.scrollToPosition(scrollX),
+      incrementScroll: (scrollXIncrement: number) =>
+          this.scrollerElement.incrementScrollPosition(scrollXIncrement),
       getScrollPosition: () => this.scrollerElement.getScrollPosition(),
       getScrollContentWidth: () => this.scrollerElement.getScrollContentWidth(),
       getOffsetWidth: () => this.mdcRoot.offsetWidth,
-      isRTL: () => window.getComputedStyle(this.mdcRoot).getPropertyValue('direction') === 'rtl',
+      isRTL: () => window.getComputedStyle(this.mdcRoot)
+                       .getPropertyValue('direction') === 'rtl',
       setActiveTab: (index: number) => this.mdcFoundation.activateTab(index),
       activateTabAtIndex: (index: number, clientRect: ClientRect) => {
         const tab = this._getTab(index);
@@ -115,17 +108,20 @@ export class TabBarBase extends BaseElement {
           tab.focus();
         }
       },
-      // TODO(sorvell): tab may not be able to synchronously answer `computeIndicatorClientRect`
-      // if an update is pending or it has not yet updated. If this is necessary,
-      // LitElement may need a `forceUpdate` method.
+      // TODO(sorvell): tab may not be able to synchronously answer
+      // `computeIndicatorClientRect` if an update is pending or it has not yet
+      // updated. If this is necessary, LitElement may need a `forceUpdate`
+      // method.
       getTabIndicatorClientRectAtIndex: (index: number) => {
         const tab = this._getTab(index);
-        return tab !== undefined ? tab.computeIndicatorClientRect() : new DOMRect();
+        return tab !== undefined ? tab.computeIndicatorClientRect() :
+                                   new DOMRect();
       },
       getTabDimensionsAtIndex: (index: number) => {
         const tab = this._getTab(index);
-        return tab !== undefined ? tab.computeDimensions() :
-          {rootLeft: 0, rootRight: 0, contentLeft: 0, contentRight: 0};
+        return tab !== undefined ?
+            tab.computeDimensions() :
+            {rootLeft: 0, rootRight: 0, contentLeft: 0, contentRight: 0};
       },
       getPreviousActiveTabIndex: () => {
         return this._previousActiveIndex;
@@ -149,8 +145,8 @@ export class TabBarBase extends BaseElement {
         // Synchronize the tabs `activeIndex` to the foundation.
         // This is needed when a tab is changed via a click, for example.
         this.activeIndex = index;
-        this.dispatchEvent(
-          new CustomEvent(MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT,
+        this.dispatchEvent(new CustomEvent(
+            MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT,
             {detail: {index}, bubbles: true, cancelable: true}));
       },
     };
@@ -159,15 +155,16 @@ export class TabBarBase extends BaseElement {
   // NOTE: Delay creating foundation until scroller is fully updated.
   // This is necessary because the foundation/adapter synchronously addresses
   // the scroller element.
-  firstUpdated() {}
+  firstUpdated() {
+  }
   protected _getUpdateComplete() {
     return super._getUpdateComplete()
-      .then(() => this.scrollerElement.updateComplete)
-      .then(() => {
-        if (this.mdcFoundation === undefined) {
-          this.createFoundation();
-        }
-      });
+        .then(() => this.scrollerElement.updateComplete)
+        .then(() => {
+          if (this.mdcFoundation === undefined) {
+            this.createFoundation();
+          }
+        });
   }
 
   scrollIndexIntoView(index: number) {

--- a/packages/tab-bar/src/mwc-tab-bar-base.ts
+++ b/packages/tab-bar/src/mwc-tab-bar-base.ts
@@ -18,7 +18,7 @@ limitations under the License.
 import '@material/mwc-tab';
 import '@material/mwc-tab-scroller';
 
-import {BaseElement, html, observer, property, query,} from '@material/mwc-base/base-element.js';
+import {BaseElement, html, observer, property, query} from '@material/mwc-base/base-element.js';
 import {Tab} from '@material/mwc-tab';
 import {TabScroller} from '@material/mwc-tab-scroller';
 import {MDCTabBarAdapter} from '@material/tab-bar/adapter';

--- a/packages/tab-bar/src/mwc-tab-bar.ts
+++ b/packages/tab-bar/src/mwc-tab-bar.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {TabBarBase} from './mwc-tab-bar-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
+
+import {TabBarBase} from './mwc-tab-bar-base.js';
 import {style} from './mwc-tab-bar-css';
 
 declare global {

--- a/packages/tab-indicator/src/mwc-tab-indicator-base.ts
+++ b/packages/tab-indicator/src/mwc-tab-indicator-base.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, BaseElement, classMap, html, property, PropertyValues, query,} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, classMap, html, property, PropertyValues, query} from '@material/mwc-base/base-element.js';
 import {MDCTabIndicatorAdapter} from '@material/tab-indicator/adapter';
 import MDCFadingTabIndicatorFoundation from '@material/tab-indicator/fading-foundation.js';
 import MDCTabIndicatorFoundation from '@material/tab-indicator/foundation';

--- a/packages/tab-indicator/src/mwc-tab-indicator-base.ts
+++ b/packages/tab-indicator/src/mwc-tab-indicator-base.ts
@@ -14,38 +14,27 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  BaseElement,
-  html,
-  property,
-  query,
-  PropertyValues,
-  classMap,
-  addHasRemoveClass,
-} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, classMap, html, property, PropertyValues, query,} from '@material/mwc-base/base-element.js';
+import {MDCTabIndicatorAdapter} from '@material/tab-indicator/adapter';
+import MDCFadingTabIndicatorFoundation from '@material/tab-indicator/fading-foundation.js';
 import MDCTabIndicatorFoundation from '@material/tab-indicator/foundation';
 import MDCSlidingTabIndicatorFoundation from '@material/tab-indicator/sliding-foundation.js';
-import MDCFadingTabIndicatorFoundation from '@material/tab-indicator/fading-foundation.js';
-import {MDCTabIndicatorAdapter} from '@material/tab-indicator/adapter';
 
 export class TabIndicatorBase extends BaseElement {
   protected mdcFoundation!: MDCTabIndicatorFoundation;
 
   protected get mdcFoundationClass() {
-    return this.fade ? MDCFadingTabIndicatorFoundation : MDCSlidingTabIndicatorFoundation;
+    return this.fade ? MDCFadingTabIndicatorFoundation :
+                       MDCSlidingTabIndicatorFoundation;
   }
 
-  @query('.mdc-tab-indicator')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-tab-indicator') protected mdcRoot!: HTMLElement;
 
-  @query('.mdc-tab-indicator__content')
-  protected contentElement!: HTMLElement;
+  @query('.mdc-tab-indicator__content') protected contentElement!: HTMLElement;
 
-  @property()
-  icon = '';
+  @property() icon = '';
 
-  @property({type: Boolean})
-  fade = false;
+  @property({type: Boolean}) fade = false;
 
   render() {
     const contentClasses = {
@@ -54,8 +43,11 @@ export class TabIndicatorBase extends BaseElement {
       'mdc-tab-indicator__content--underline': !this.icon,
     };
     return html`
-      <span class="mdc-tab-indicator ${classMap({'mdc-tab-indicator--fade': this.fade})}">
-        <span class="mdc-tab-indicator__content ${classMap(contentClasses)}">${this.icon}</span>
+      <span class="mdc-tab-indicator ${classMap({
+      'mdc-tab-indicator--fade': this.fade
+    })}">
+        <span class="mdc-tab-indicator__content ${classMap(contentClasses)}">${
+        this.icon}</span>
       </span>
       `;
   }
@@ -69,9 +61,10 @@ export class TabIndicatorBase extends BaseElement {
   createAdapter(): MDCTabIndicatorAdapter {
     return {
       ...addHasRemoveClass(this.mdcRoot),
-      computeContentClientRect: () => this.contentElement.getBoundingClientRect(),
+      computeContentClientRect: () =>
+          this.contentElement.getBoundingClientRect(),
       setContentStyleProperty: (prop: string, value: string) =>
-        this.contentElement.style.setProperty(prop, value),
+          this.contentElement.style.setProperty(prop, value),
     };
   }
 

--- a/packages/tab-indicator/src/mwc-tab-indicator.ts
+++ b/packages/tab-indicator/src/mwc-tab-indicator.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {TabIndicatorBase} from './mwc-tab-indicator-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
+
+import {TabIndicatorBase} from './mwc-tab-indicator-base.js';
 import {style} from './mwc-tab-indicator-css.js';
 
 declare global {

--- a/packages/tab-scroller/src/mwc-tab-scroller-base.ts
+++ b/packages/tab-scroller/src/mwc-tab-scroller-base.ts
@@ -14,24 +14,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  BaseElement,
-  html,
-  query,
-  eventOptions,
-  addHasRemoveClass,
-} from '@material/mwc-base/base-element';
-import MDCTabScrollerFoundation from '@material/tab-scroller/foundation.js';
 import {matches} from '@material/dom/ponyfill';
+import {addHasRemoveClass, BaseElement, eventOptions, html, query,} from '@material/mwc-base/base-element';
 import {MDCTabScrollerAdapter} from '@material/tab-scroller/adapter';
+import MDCTabScrollerFoundation from '@material/tab-scroller/foundation.js';
 
 export class TabScrollerBase extends BaseElement {
   protected mdcFoundation!: MDCTabScrollerFoundation;
 
   protected mdcFoundationClass = MDCTabScrollerFoundation;
 
-  @query('.mdc-tab-scroller')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-tab-scroller') protected mdcRoot!: HTMLElement;
 
   @query('.mdc-tab-scroller__scroll-area')
   protected scrollAreaElement!: HTMLElement;
@@ -70,24 +63,30 @@ export class TabScrollerBase extends BaseElement {
     return {
       ...addHasRemoveClass(this.mdcRoot),
       eventTargetMatchesSelector: (evtTarget: EventTarget, selector: string) =>
-        matches(evtTarget as Element, selector),
-      addScrollAreaClass: (className: string) => this.scrollAreaElement.classList.add(className),
+          matches(evtTarget as Element, selector),
+      addScrollAreaClass: (className: string) =>
+          this.scrollAreaElement.classList.add(className),
       setScrollAreaStyleProperty: (prop: string, value: string) =>
-        this.scrollAreaElement.style.setProperty(prop, value),
+          this.scrollAreaElement.style.setProperty(prop, value),
       setScrollContentStyleProperty: (prop: string, value: string) =>
-        this.scrollContentElement.style.setProperty(prop, value),
+          this.scrollContentElement.style.setProperty(prop, value),
       getScrollContentStyleValue: (propName: string) =>
-        window.getComputedStyle(this.scrollContentElement).getPropertyValue(propName),
-      setScrollAreaScrollLeft: (scrollX: number) => this.scrollAreaElement.scrollLeft = scrollX,
+          window.getComputedStyle(this.scrollContentElement)
+              .getPropertyValue(propName),
+      setScrollAreaScrollLeft: (scrollX: number) =>
+          this.scrollAreaElement.scrollLeft = scrollX,
       getScrollAreaScrollLeft: () => this.scrollAreaElement.scrollLeft,
       getScrollContentOffsetWidth: () => this.scrollContentElement.offsetWidth,
       getScrollAreaOffsetWidth: () => this.scrollAreaElement.offsetWidth,
-      computeScrollAreaClientRect: () => this.scrollAreaElement.getBoundingClientRect(),
-      computeScrollContentClientRect: () => this.scrollContentElement.getBoundingClientRect(),
+      computeScrollAreaClientRect: () =>
+          this.scrollAreaElement.getBoundingClientRect(),
+      computeScrollContentClientRect: () =>
+          this.scrollContentElement.getBoundingClientRect(),
       computeHorizontalScrollbarHeight: () => {
         if (this._scrollbarHeight === -1) {
           this.scrollAreaElement.style.overflowX = 'scroll';
-          this._scrollbarHeight = this.scrollAreaElement.offsetHeight - this.scrollAreaElement.clientHeight;
+          this._scrollbarHeight = this.scrollAreaElement.offsetHeight -
+              this.scrollAreaElement.clientHeight;
           this.scrollAreaElement.style.overflowX = '';
         }
         return this._scrollbarHeight;
@@ -113,7 +112,8 @@ export class TabScrollerBase extends BaseElement {
 
   /**
    * Increments the scroll value by the given amount
-   * @param {number} scrollXIncrement The pixel value by which to increment the scroll value
+   * @param {number} scrollXIncrement The pixel value by which to increment the
+   *     scroll value
    */
   incrementScrollPosition(scrollXIncrement: number) {
     this.mdcFoundation.incrementScroll(scrollXIncrement);

--- a/packages/tab-scroller/src/mwc-tab-scroller-base.ts
+++ b/packages/tab-scroller/src/mwc-tab-scroller-base.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {matches} from '@material/dom/ponyfill';
-import {addHasRemoveClass, BaseElement, eventOptions, html, query,} from '@material/mwc-base/base-element';
+import {addHasRemoveClass, BaseElement, eventOptions, html, query} from '@material/mwc-base/base-element';
 import {MDCTabScrollerAdapter} from '@material/tab-scroller/adapter';
 import MDCTabScrollerFoundation from '@material/tab-scroller/foundation.js';
 

--- a/packages/tab-scroller/src/mwc-tab-scroller.ts
+++ b/packages/tab-scroller/src/mwc-tab-scroller.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {TabScrollerBase} from './mwc-tab-scroller-base.js';
 import {customElement} from '@material/mwc-base/base-element';
+
+import {TabScrollerBase} from './mwc-tab-scroller-base.js';
 import {style} from './mwc-tab-scroller-css.js';
 
 declare global {

--- a/packages/tab/src/mwc-tab-base.ts
+++ b/packages/tab/src/mwc-tab-base.ts
@@ -98,22 +98,16 @@ export class TabBase extends BaseElement {
         <span class="mdc-tab__content">
           <slot></slot>
           ${
-        this.icon ?
-        html
-    `<span class="mdc-tab__icon material-icons">${this.icon}</span>`: ''}
+        this.icon ? html`<span class="mdc-tab__icon material-icons">${
+                        this.icon}</span>` :
+                    ''}
           ${
         this.label ?
-        html
-    `<span class="mdc-tab__text-label">${this.label}</span>`: ''}
-          ${
-        this.isMinWidthIndicator ?
-        this.renderIndicator() :
-        ''}
+            html`<span class="mdc-tab__text-label">${this.label}</span>` :
+            ''}
+          ${this.isMinWidthIndicator ? this.renderIndicator() : ''}
         </span>
-        ${
-        this.isMinWidthIndicator ?
-        '' :
-        this.renderIndicator()}
+        ${this.isMinWidthIndicator ? '' : this.renderIndicator()}
         <span class="mdc-tab__ripple" .ripple="${ripple({
       interactionNode: this,
       unbounded: false

--- a/packages/tab/src/mwc-tab-base.ts
+++ b/packages/tab/src/mwc-tab-base.ts
@@ -14,16 +14,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {BaseElement, html, property, query, classMap, addHasRemoveClass} from '@material/mwc-base/base-element.js';
-import {TabIndicator} from '@material/mwc-tab-indicator';
-
 // Make TypeScript not remove the import.
 import '@material/mwc-tab-indicator';
 
+import {addHasRemoveClass, BaseElement, classMap, html, property, query} from '@material/mwc-base/base-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive';
-import MDCTabFoundation from '@material/tab/foundation';
-import {style} from './mwc-tab-css';
+import {TabIndicator} from '@material/mwc-tab-indicator';
 import {MDCTabAdapter} from '@material/tab/adapter';
+import MDCTabFoundation from '@material/tab/foundation';
+
+import {style} from './mwc-tab-css';
 
 // used for generating unique id for each tab
 let tabIdCounter = 0;
@@ -33,32 +33,23 @@ export class TabBase extends BaseElement {
 
   protected readonly mdcFoundationClass = MDCTabFoundation;
 
-  @query('.mdc-tab')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-tab') protected mdcRoot!: HTMLElement;
 
-  @query('mwc-tab-indicator')
-  protected tabIndicator!: TabIndicator;
+  @query('mwc-tab-indicator') protected tabIndicator!: TabIndicator;
 
-  @property()
-  label = '';
+  @property() label = '';
 
-  @property()
-  icon = '';
+  @property() icon = '';
 
-  @property({type: Boolean})
-  isFadingIndicator = false;
+  @property({type: Boolean}) isFadingIndicator = false;
 
-  @property({type: Boolean})
-  minWidth = false;
+  @property({type: Boolean}) minWidth = false;
 
-  @property({type: Boolean})
-  isMinWidthIndicator = false;
+  @property({type: Boolean}) isMinWidthIndicator = false;
 
-  @property()
-  indicatorIcon = '';
+  @property() indicatorIcon = '';
 
-  @property({type: Boolean})
-  stacked = false;
+  @property({type: Boolean}) stacked = false;
 
   /**
    * Other properties
@@ -67,11 +58,9 @@ export class TabBase extends BaseElement {
    * onTransitionEnd (needed?)
    */
 
-  @query('mwc-tab-indicator')
-  private _tabIndicator!: HTMLElement;
+  @query('mwc-tab-indicator') private _tabIndicator!: HTMLElement;
 
-  @query('.mdc-tab__content')
-  private _contentElement!: HTMLElement;
+  @query('.mdc-tab__content') private _contentElement!: HTMLElement;
 
   private _handleClick() {
     this.mdcFoundation.handleClick();
@@ -108,12 +97,27 @@ export class TabBase extends BaseElement {
         tabindex="-1">
         <span class="mdc-tab__content">
           <slot></slot>
-          ${this.icon ? html`<span class="mdc-tab__icon material-icons">${this.icon}</span>` : ''}
-          ${this.label ? html`<span class="mdc-tab__text-label">${this.label}</span>` : ''}
-          ${this.isMinWidthIndicator ? this.renderIndicator() : ''}
+          ${
+        this.icon ?
+        html
+    `<span class="mdc-tab__icon material-icons">${this.icon}</span>`: ''}
+          ${
+        this.label ?
+        html
+    `<span class="mdc-tab__text-label">${this.label}</span>`: ''}
+          ${
+        this.isMinWidthIndicator ?
+        this.renderIndicator() :
+        ''}
         </span>
-        ${this.isMinWidthIndicator ? '' : this.renderIndicator()}
-        <span class="mdc-tab__ripple" .ripple="${ripple({interactionNode: this, unbounded: false})}"></span>
+        ${
+        this.isMinWidthIndicator ?
+        '' :
+        this.renderIndicator()}
+        <span class="mdc-tab__ripple" .ripple="${ripple({
+      interactionNode: this,
+      unbounded: false
+    })}"></span>
       </button>`;
   }
 
@@ -127,18 +131,20 @@ export class TabBase extends BaseElement {
   createAdapter(): MDCTabAdapter {
     return {
       ...addHasRemoveClass(this.mdcRoot),
-      setAttr: (attr: string, value: string) => this.mdcRoot.setAttribute(attr, value),
+      setAttr: (attr: string, value: string) =>
+          this.mdcRoot.setAttribute(attr, value),
       activateIndicator: (previousIndicatorClientRect: ClientRect) =>
-        (this._tabIndicator as TabIndicator).activate(previousIndicatorClientRect),
+          (this._tabIndicator as TabIndicator)
+              .activate(previousIndicatorClientRect),
       deactivateIndicator: () =>
-        (this._tabIndicator as TabIndicator).deactivate(),
+          (this._tabIndicator as TabIndicator).deactivate(),
       notifyInteracted: () => this.dispatchEvent(
-        new CustomEvent(MDCTabFoundation.strings.INTERACTED_EVENT, {
-          detail: {tabId: this.id},
-          bubbles: true,
-          composed: true,
-          cancelable: true,
-        })),
+          new CustomEvent(MDCTabFoundation.strings.INTERACTED_EVENT, {
+            detail: {tabId: this.id},
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+          })),
       getOffsetLeft: () => this.offsetLeft,
       getOffsetWidth: () => this.mdcRoot.offsetWidth,
       getContentOffsetLeft: () => this._contentElement.offsetLeft,

--- a/packages/tab/src/mwc-tab.ts
+++ b/packages/tab/src/mwc-tab.ts
@@ -14,9 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {TabBase} from './mwc-tab-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
 
+import {TabBase} from './mwc-tab-base.js';
 import {style} from './mwc-tab-css';
 
 declare global {

--- a/packages/top-app-bar/src/mwc-top-app-bar-base.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar-base.ts
@@ -14,49 +14,37 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  BaseElement,
-  html,
-  property,
-  query,
-  PropertyValues,
-  classMap,
-  addHasRemoveClass,
-} from '@material/mwc-base/base-element.js';
-import MDCTopAppBarBaseFoundation from '@material/top-app-bar/foundation';
-import MDCTopAppBarFoundation from '@material/top-app-bar/standard/foundation.js';
-import MDCShortTopAppBarFoundation from '@material/top-app-bar/short/foundation.js';
-import MDCFixedTopAppBarFoundation from '@material/top-app-bar/fixed/foundation.js';
-import {strings} from '@material/top-app-bar/constants.js';
+import {addHasRemoveClass, BaseElement, classMap, html, property, PropertyValues, query,} from '@material/mwc-base/base-element.js';
 import {MDCTopAppBarAdapter} from '@material/top-app-bar/adapter';
+import {strings} from '@material/top-app-bar/constants.js';
+import MDCFixedTopAppBarFoundation from '@material/top-app-bar/fixed/foundation.js';
+import MDCTopAppBarBaseFoundation from '@material/top-app-bar/foundation';
+import MDCShortTopAppBarFoundation from '@material/top-app-bar/short/foundation.js';
+import MDCTopAppBarFoundation from '@material/top-app-bar/standard/foundation.js';
 
-type TopAppBarTypes = ''|'fixed'|'prominent'|'short'|'shortCollapsed'|'prominentFixed';
+type TopAppBarTypes =
+    ''|'fixed'|'prominent'|'short'|'shortCollapsed'|'prominentFixed';
 
 export class TopAppBarBase extends BaseElement {
   protected mdcFoundation!: MDCTopAppBarBaseFoundation;
 
   protected get mdcFoundationClass() {
-    return this.type === 'fixed' || this.type === 'prominentFixed'
-      ? MDCFixedTopAppBarFoundation
-      : (this.type === 'short' || this.type === 'shortCollapsed'
-        ? MDCShortTopAppBarFoundation
-        : MDCTopAppBarFoundation);
+    return this.type === 'fixed' || this.type === 'prominentFixed' ?
+        MDCFixedTopAppBarFoundation :
+        (this.type === 'short' || this.type === 'shortCollapsed' ?
+             MDCShortTopAppBarFoundation :
+             MDCTopAppBarFoundation);
   }
 
-  @query('.mdc-top-app-bar')
-  protected mdcRoot!: HTMLElement;
+  @query('.mdc-top-app-bar') protected mdcRoot!: HTMLElement;
 
-  @query('[name="actionItems"]')
-  private _actionItemsSlot!: HTMLSlotElement;
+  @query('[name="actionItems"]') private _actionItemsSlot!: HTMLSlotElement;
 
-  @property({reflect: true})
-  type: TopAppBarTypes = '';
+  @property({reflect: true}) type: TopAppBarTypes = '';
 
-  @property({type: Boolean, reflect: true})
-  dense = false;
+  @property({type: Boolean, reflect: true}) dense = false;
 
-  @property({type: Boolean, reflect: true})
-  centerTitle = false;
+  @property({type: Boolean, reflect: true}) centerTitle = false;
 
   private _scrollTarget!: HTMLElement|Window;
 
@@ -75,25 +63,31 @@ export class TopAppBarBase extends BaseElement {
   // user brings a web component with a ripple if rippling is desired.
   render() {
     const classes = {
-      'mdc-top-app-bar--fixed': this.type === 'fixed' || this.type === 'prominentFixed',
-      'mdc-top-app-bar--short': this.type === 'shortCollapsed' || this.type === 'short',
+      'mdc-top-app-bar--fixed':
+          this.type === 'fixed' || this.type === 'prominentFixed',
+      'mdc-top-app-bar--short':
+          this.type === 'shortCollapsed' || this.type === 'short',
       'mdc-top-app-bar--short-collapsed': this.type === 'shortCollapsed',
-      'mdc-top-app-bar--prominent': this.type === 'prominent' || this.type === 'prominentFixed',
+      'mdc-top-app-bar--prominent':
+          this.type === 'prominent' || this.type === 'prominentFixed',
       'mdc-top-app-bar--dense': this.dense,
       'mwc-top-app-bar--center-title': this.centerTitle,
     };
     const alignStartTitle = !this.centerTitle ? html`
       <span class="mdc-top-app-bar__title"><slot name="title"></slot></span>
-    ` : '';
+    ` :
+                                                '';
     const centerSection = this.centerTitle ? html`
       <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">
         <span class="mdc-top-app-bar__title"><slot name="title"></slot></span>
-      </section>` : '';
+      </section>` :
+                                             '';
     return html`
       <header class="mdc-top-app-bar ${classMap(classes)}">
       <div class="mdc-top-app-bar__row">
         <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
-          <slot name="navigationIcon" @click=${this.handleNavigationClick}></slot>
+          <slot name="navigationIcon" @click=${
+        this.handleNavigationClick}></slot>
           ${alignStartTitle}
         </section>
         ${centerSection}
@@ -108,43 +102,51 @@ export class TopAppBarBase extends BaseElement {
     return {
       ...addHasRemoveClass(this.mdcRoot),
       setStyle: (property: string, value: string) =>
-        this.mdcRoot.style.setProperty(property, value),
+          this.mdcRoot.style.setProperty(property, value),
       getTopAppBarHeight: () => this.mdcRoot.clientHeight,
       notifyNavigationIconClicked: () => {
-        this.dispatchEvent(new Event(strings.NAVIGATION_EVENT, {bubbles: true, cancelable: true}));
+        this.dispatchEvent(new Event(
+            strings.NAVIGATION_EVENT, {bubbles: true, cancelable: true}));
       },
       getViewportScrollY: () => this.scrollTarget instanceof Window ?
-        this.scrollTarget.pageYOffset :
-        this.scrollTarget.scrollTop,
+          this.scrollTarget.pageYOffset :
+          this.scrollTarget.scrollTop,
       getTotalActionItems: () =>
-        this._actionItemsSlot.assignedNodes({flatten: true}).length,
+          this._actionItemsSlot.assignedNodes({flatten: true}).length,
     };
   }
 
-  // override that prevents `super.firstUpdated` since we are controlling when `createFoundation` is called.
-  firstUpdated() {}
+  // override that prevents `super.firstUpdated` since we are controlling when
+  // `createFoundation` is called.
+  firstUpdated() {
+  }
 
   updated(changedProperties: PropertyValues) {
     // update foundation if `type` or `scrollTarget` changes
-    if (changedProperties.has('type') || changedProperties.has('scrollTarget')) {
+    if (changedProperties.has('type') ||
+        changedProperties.has('scrollTarget')) {
       this.createFoundation();
     }
   }
 
-  protected handleTargetScroll = () => {
-    this.mdcFoundation.handleTargetScroll();
-  }
+  protected handleTargetScroll =
+      () => {
+        this.mdcFoundation.handleTargetScroll();
+      }
 
-  protected handleResize = () => {
-    this.mdcFoundation.handleWindowResize();
-  }
+  protected handleResize =
+      () => {
+        this.mdcFoundation.handleWindowResize();
+      }
 
-  protected handleNavigationClick = () => {
-    this.mdcFoundation.handleNavigationClick();
-  }
+  protected handleNavigationClick =
+      () => {
+        this.mdcFoundation.handleNavigationClick();
+      }
 
   protected registerListeners() {
-    this.scrollTarget.addEventListener('scroll', this.handleTargetScroll, {passive: true});
+    this.scrollTarget.addEventListener(
+        'scroll', this.handleTargetScroll, {passive: true});
 
     if (this.type !== 'short' && this.type !== 'fixed') {
       window.addEventListener('resize', this.handleResize, {passive: true});

--- a/packages/top-app-bar/src/mwc-top-app-bar-base.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar-base.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, BaseElement, classMap, html, property, PropertyValues, query,} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, classMap, html, property, PropertyValues, query} from '@material/mwc-base/base-element.js';
 import {MDCTopAppBarAdapter} from '@material/top-app-bar/adapter';
 import {strings} from '@material/top-app-bar/constants.js';
 import MDCFixedTopAppBarFoundation from '@material/top-app-bar/fixed/foundation.js';

--- a/packages/top-app-bar/src/mwc-top-app-bar.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {TopAppBarBase} from './mwc-top-app-bar-base.js';
 import {customElement} from '@material/mwc-base/base-element.js';
+
+import {TopAppBarBase} from './mwc-top-app-bar-base.js';
 import {style} from './mwc-top-app-bar-css.js';
 
 declare global {

--- a/test/benchmark/button/test-basic.ts
+++ b/test/benchmark/button/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-button';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-button label="Normal"></mwc-button>

--- a/test/benchmark/checkbox/test-basic.ts
+++ b/test/benchmark/checkbox/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-checkbox';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-checkbox checked></mwc-checkbox>

--- a/test/benchmark/cli.ts
+++ b/test/benchmark/cli.ts
@@ -1,8 +1,8 @@
-import {main} from 'tachometer/lib/cli';
-import {readdirSync} from 'fs';
-import {join as pathjoin} from 'path';
 import * as commandLineArgs from 'command-line-args';
 import * as commandLineUsage from 'command-line-usage';
+import {readdirSync} from 'fs';
+import {join as pathjoin} from 'path';
+import {main} from 'tachometer/lib/cli';
 
 const optionDefinitions: commandLineUsage.OptionDefinition[] = [
   {
@@ -13,7 +13,7 @@ const optionDefinitions: commandLineUsage.OptionDefinition[] = [
   },
   {
     name: 'package',
-    description: 'Select which individual packages to benchmark.\ne.g.'+
+    description: 'Select which individual packages to benchmark.\ne.g.' +
         ' "-p button radio icon-button".\n(default runs all)',
     alias: 'p',
     type: String,
@@ -92,33 +92,34 @@ $ node test/benchmark/cli -n 20
   if (opts.package.length) {
     packages = opts.package;
   } else {
-    packages = readdirSync(pathjoin('test','benchmark'), {withFileTypes: true})
-      .filter(dirEntry => dirEntry.isDirectory())
-      .map(dirEntry => dirEntry.name);
+    packages = readdirSync(pathjoin('test', 'benchmark'), {withFileTypes: true})
+                   .filter(dirEntry => dirEntry.isDirectory())
+                   .map(dirEntry => dirEntry.name);
   }
 
 
   const printResults: string[] = [];
   for (const packageName of packages) {
-
     const runCommands: string[] = [];
 
-    const benchmarks = readdirSync(pathjoin('test','benchmark', packageName), {withFileTypes: true})
-        .filter(dirEntry => dirEntry.isFile() && dirEntry.name.endsWith('.js'))
-        .map(dirEntry => dirEntry.name.replace(/\.js$/, ''));
+    const benchmarks =
+        readdirSync(
+            pathjoin('test', 'benchmark', packageName), {withFileTypes: true})
+            .filter(
+                dirEntry => dirEntry.isFile() && dirEntry.name.endsWith('.js'))
+            .map(dirEntry => dirEntry.name.replace(/\.js$/, ''));
 
     for (const benchmark of benchmarks) {
       runCommands.push(
-        `${packageName}:${benchmark}=test/benchmark/bench-runner.html` +
-        `?bench=${benchmark}` +
-        `&package=${packageName}`
-      );
+          `${packageName}:${benchmark}=test/benchmark/bench-runner.html` +
+          `?bench=${benchmark}` +
+          `&package=${packageName}`);
     }
 
     const statResults = await main([
       ...runCommands,
       '--measure=global',
-      `--browser=${opts.browser}${opts.remote ? `@${opts.remote}`: ''}`,
+      `--browser=${opts.browser}${opts.remote ? `@${opts.remote}` : ''}`,
       `--sample-size=${opts['sample-size']}`
     ]);
 

--- a/test/benchmark/drawer/test-basic.ts
+++ b/test/benchmark/drawer/test-basic.ts
@@ -1,7 +1,7 @@
 import '@material/mwc-drawer';
 import '@material/mwc-top-app-bar';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-drawer hasHeader>

--- a/test/benchmark/fab/test-basic.ts
+++ b/test/benchmark/fab/test-basic.ts
@@ -1,7 +1,7 @@
 import '@material/mwc-fab';
 import '@material/mwc-icon';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-fab icon="explore" label="Explore the world. (This is an example label.)"></mwc-fab>

--- a/test/benchmark/formfield/test-basic.ts
+++ b/test/benchmark/formfield/test-basic.ts
@@ -1,7 +1,7 @@
 import '@material/mwc-formfield';
 import '@material/mwc-radio';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-formfield label="This is a radio."></mwc-formfield>

--- a/test/benchmark/helpers.ts
+++ b/test/benchmark/helpers.ts
@@ -1,5 +1,5 @@
-import { customElement, html, LitElement, property } from 'lit-element';
-import { TemplateResult, render } from 'lit-html';
+import {customElement, html, LitElement, property} from 'lit-element';
+import {render, TemplateResult} from 'lit-html';
 
 declare global {
   interface Window {
@@ -9,11 +9,9 @@ declare global {
 
 @customElement('test-fixture')
 export class TestFixture extends LitElement {
-  @property({ type: Boolean })
-  shouldAttachContents = true;
+  @property({type: Boolean}) shouldAttachContents = true;
 
-  @property({ type: Object })
-  template: TemplateResult = html``;
+  @property({type: Object}) template: TemplateResult = html``;
 
   remove(): boolean {
     const parent = this.parentNode;
@@ -74,19 +72,17 @@ interface FixtureOptions {
   document: Document;
 }
 
-export const fixture = (
-  template: TemplateResult,
-  options?: Partial<FixtureOptions>
-) => {
-  const opts: FixtureOptions = { ...defaultOpts, ...options };
-  const tf = opts.document.createElement('test-fixture') as TestFixture;
-  tf.shouldAttachContents = opts.shouldAttachContents;
-  tf.template = template;
+export const fixture =
+    (template: TemplateResult, options?: Partial<FixtureOptions>) => {
+      const opts: FixtureOptions = {...defaultOpts, ...options};
+      const tf = opts.document.createElement('test-fixture') as TestFixture;
+      tf.shouldAttachContents = opts.shouldAttachContents;
+      tf.template = template;
 
-  opts.document.body.appendChild(tf);
+      opts.document.body.appendChild(tf);
 
-  return tf;
-};
+      return tf;
+    };
 
 interface MeasureFixtureCreationOpts {
   afterRender?: (root: ShadowRoot) => Promise<unknown>;

--- a/test/benchmark/icon-button/test-basic.ts
+++ b/test/benchmark/icon-button/test-basic.ts
@@ -1,7 +1,7 @@
 import '@material/mwc-icon-button';
 import '@material/mwc-icon';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-icon-button icon="error"></mwc-icon-button>

--- a/test/benchmark/icon/test-basic.ts
+++ b/test/benchmark/icon/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-icon';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-icon>sentiment_very_satisfied</mwc-icon>

--- a/test/benchmark/linear-progress/test-basic.ts
+++ b/test/benchmark/linear-progress/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-linear-progress';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-linear-progress determinate progress="0.5" buffer="1">

--- a/test/benchmark/radio/test-basic.ts
+++ b/test/benchmark/radio/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-radio';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-radio id="s.1" name="s"></mwc-radio>

--- a/test/benchmark/ripple/test-basic.ts
+++ b/test/benchmark/ripple/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-ripple';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <div class="demo-box">Primary<mwc-ripple primary></mwc-ripple></div>

--- a/test/benchmark/slider/test-basic.ts
+++ b/test/benchmark/slider/test-basic.ts
@@ -1,7 +1,7 @@
 import '@material/mwc-slider';
 import '@material/mwc-checkbox';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-slider discrete markers max="50" value="10" step="5"></mwc-slider>

--- a/test/benchmark/snackbar/test-basic.ts
+++ b/test/benchmark/snackbar/test-basic.ts
@@ -1,17 +1,21 @@
 import '@material/mwc-snackbar';
 import '@material/mwc-checkbox';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
-import { Snackbar } from '@material/mwc-snackbar';
 
-measureFixtureCreation(html`
+import {Snackbar} from '@material/mwc-snackbar';
+import {html} from 'lit-html';
+
+import {measureFixtureCreation} from '../helpers';
+
+measureFixtureCreation(
+    html`
   <mwc-snackbar id="snack1" labelText="Can't send photo. Retry in 5 seconds.">
     <div id="actionButton" slot="action">RETRY</div>
     <div id="iconButton" slot="dismiss">DISMISS</div>
   </mwc-snackbar>
-`, {
-  afterRender: async (root) => {
-    const snackbar = root.querySelector('#snack1') as Snackbar;
-    snackbar.open();
-  }
-});
+`,
+    {
+      afterRender: async (root) => {
+        const snackbar = root.querySelector('#snack1') as Snackbar;
+        snackbar.open();
+      }
+    });

--- a/test/benchmark/switch/test-basic.ts
+++ b/test/benchmark/switch/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-switch';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-switch checked></mwc-switch>

--- a/test/benchmark/tab-bar/test-basic.ts
+++ b/test/benchmark/tab-bar/test-basic.ts
@@ -1,7 +1,7 @@
 import '@material/mwc-tab-bar';
 import '@material/mwc-tab';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-tab-bar>

--- a/test/benchmark/tab/test-basic.ts
+++ b/test/benchmark/tab/test-basic.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-tab';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-tab label="one"></mwc-tab>

--- a/test/benchmark/top-app-bar/test-basic.ts
+++ b/test/benchmark/top-app-bar/test-basic.ts
@@ -1,7 +1,7 @@
 import '@material/mwc-top-app-bar';
 import '@material/mwc-icon-button';
-import { html } from 'lit-html';
-import { measureFixtureCreation } from '../helpers';
+import {html} from 'lit-html';
+import {measureFixtureCreation} from '../helpers';
 
 measureFixtureCreation(html`
   <mwc-top-app-bar>


### PR DESCRIPTION
Updated the script to include test files, and to make sure we don't try to format files in node_modules.

Also removes trailing commas from imports. It looks like clang-format preserves them if they are there, but they were only there because of the other format config we had in the earlier PR.

cc @43081j 