### PR TITLE
update eslint plugin

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -13,6 +13,9 @@ plugins:
 parserOptions:
   ecmaVersion: 2017
   sourceType: module
+settings:
+  wc:
+    elementBaseClasses: ["BaseElement"]
 rules:
   indent: [warn, 2]
   max-len: [warn, 120]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,7 +15,7 @@ parserOptions:
   sourceType: module
 settings:
   wc:
-    elementBaseClasses: ["BaseElement"]
+    elementBaseClasses: ["BaseElement", "LitElement", "FormElement"]
 rules:
   indent: [warn, 2]
   max-len: [warn, 120]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6540,9 +6540,9 @@
       }
     },
     "eslint-plugin-wc": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-wc/-/eslint-plugin-wc-1.1.1.tgz",
-      "integrity": "sha512-9qwM/jXSDQ0ip14D49Ip0uQmZtsLive9VqF5tmRnmzpSI4CvAmaSIK0oYXihBA5ssIG4u4S8G3eb3HaK+7qveQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-wc/-/eslint-plugin-wc-1.2.0.tgz",
+      "integrity": "sha512-p1Vv8GkiTS8ZNfsmWvNJfKsGwsfCDteo2QsFE53x5DuHN7YDVf36II46DauP3mBCQ9pZnYD8lZyl/uz3qBtwQw==",
       "dev": true,
       "requires": {
         "js-levenshtein-esm": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint": "^5.16.0",
     "eslint-config-google": "^0.13.0",
     "eslint-plugin-mocha": "^5.3.0",
-    "eslint-plugin-wc": "^1.1.1",
+    "eslint-plugin-wc": "^1.2.0",
     "glob": "^7.1.1",
     "karma": "^4.0.1",
     "karma-chai": "^0.1.0",

--- a/packages/tab/src/mwc-tab-base.ts
+++ b/packages/tab/src/mwc-tab-base.ts
@@ -88,8 +88,8 @@ export class TabBase extends BaseElement {
 
   static styles = style;
 
-  constructor() {
-    super();
+  firstUpdated() {
+    super.firstUpdated();
     // create an unique id
     this.id = this.id || `mdc-tab-${++tabIdCounter}`;
   }


### PR DESCRIPTION
This sorts the problem that the base classes aren't being linted at the min.

The linter works by looking for a customElement decorator or JSDoc, of which the base classes have none. So i've gone ahead and added the setting in to specify `BaseElement` as a custom element base class.

~weird one here is that `firstUpdated` needs to pass on the `PropertyValues` parameter to `super`. should we just.. import that type from lit or what? the tab package doesn't have lit as a dependency so that seems not-so-right to do.~
nvm seems baseelement has no change param

cc @aomarks 