### PR TITLE
Fix <mwc-tab-bar> layout issue in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   users have control over how fonts are loaded. Users can still import the
   `mwc-icon-font.js` module themselves to automatically load the font from
   fonts.googleapis.com.
+- Fix layout issue affecting scrolling `<mwc-tab-bar>` in Firefox.
 
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x

--- a/packages/tab-bar/src/mwc-tab-bar.scss
+++ b/packages/tab-bar/src/mwc-tab-bar.scss
@@ -18,7 +18,7 @@ limitations under the License.
 @import '@material/tab-bar/mdc-tab-bar.scss';
 
 :host {
-  display: flex;
+  display: block;
 }
 
 .mdc-tab-bar {


### PR DESCRIPTION
If an `<mwc-tab-bar>`'s container doesn't fit the bar with all its tabs, then the tabs should not overflow the container, and should automatically scroll horizontally so that the selected tab is displayed, like this:

![image](https://user-images.githubusercontent.com/48894/62583700-1fba7880-b866-11e9-9d94-f2f92694c487.png)

This is what we get in in Chrome 76. But in Firefox 68, we get this:

![image](https://user-images.githubusercontent.com/48894/62583752-614b2380-b866-11e9-8bff-7cf8125b0eef.png)

Changing the style to `:host { display: block; }` makes the behavior match. There seems to be an inconsistency between Firefox and Chrome here -- maybe a Firefox bug? Changing `display` to any of: `unset`, `block`, or `inline` works, but `flex-inline` has the same problem.

I'm also wondering why we put `display:flex` on the host anyway? My (very possibly wrong) understanding was that `display:flex` is equivalent to `display:block` in terms of the layout of the flex container *itself* (where `display: inline-flex` would be the equivalent where the flex container is `inline`), and also that `display` wouldn't be inherited to any children in the shadow root, so it should have no effect there. If that's true, it doesn't *seem* that `display:flex` does anything useful vs `display:block`?

Repro:

```html
<!doctype html>
<html>
  <head>
    <style>
      body {
        margin: 0;
        width: 225px;
      }
      /* uncomment below to fix */
      /*
      mwc-tab-bar {
        display: unset;
      }
      */
    </style>
  </head>
  <body>
    <script type="module">
      import '@material/mwc-tab-bar';
      import '@material/mwc-tab';
    </script>

    <mwc-tab-bar>
      <mwc-tab label="Tab 1"></mwc-tab>
      <mwc-tab label="Tab 2"></mwc-tab>
      <mwc-tab label="Tab 3"></mwc-tab>
      <mwc-tab label="Tab 4"></mwc-tab>
    </mwc-tab-bar>
  </body>
</html>
```