### PR TITLE
Fix IE11 icon rendering in <mwc-icon>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `mwc-icon-font.js` module themselves to automatically load the font from
   fonts.googleapis.com.
 - Fix layout issue affecting scrolling `<mwc-tab-bar>` in Firefox.
+- Fix bug where `<mwc-icon>` icons did not render in IE11.
 
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x

--- a/packages/icon/src/_mwc-icon.scss
+++ b/packages/icon/src/_mwc-icon.scss
@@ -26,6 +26,13 @@ limitations under the License.
   white-space: nowrap;
   word-wrap: normal;
   direction: ltr;
-  -webkit-font-feature-settings: 'liga';
+
+  /* Support for all WebKit browsers. */
   -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+  /* Support for IE. */
+  font-feature-settings: 'liga';
 }


### PR DESCRIPTION
IE11 requires `font-feature-settings: 'liga'` to be turned on to render ligatures.

I also synchronized this styling generally to exactly match the recommendations at https://google.github.io/material-design-icons/#icon-images-for-the-web

Fixes https://github.com/material-components/material-components-web-components/issues/122