### PR TITLE
Fix <mwc-snackbar> default action/dismiss button styles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   fonts.googleapis.com.
 - Fix layout issue affecting scrolling `<mwc-tab-bar>` in Firefox.
 - Fix bug where `<mwc-icon>` icons did not render in IE11.
+- Buttons slotted into `<mwc-snackbar>` now render with correct default styles.
+  Add `--mdc-snackbar-action-color` CSS custom property to override default
+  action button color.
 
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -25,15 +25,6 @@ limitations under the License.
   <script type="module" src="../node_modules/@material/mwc-icon-button/mwc-icon-button.js"></script>
   <script type="module" src="../node_modules/@material/mwc-icon/mwc-icon.js"></script>
   <link rel="stylesheet" href="demo-component.css">
-  <style>
-    #actionButton {
-      --mdc-theme-on-primary: black;
-      --mdc-theme-primary: #bb86fc;
-    }
-    #iconButton {
-      color: white;
-    }
-  </style>
 </head>
 <body class="unresolved">
   <header>

--- a/packages/snackbar/src/mwc-snackbar.scss
+++ b/packages/snackbar/src/mwc-snackbar.scss
@@ -15,3 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 @import '@material/snackbar/mdc-snackbar.scss';
+
+slot[name=action]::slotted(mwc-button) {
+  --mdc-theme-primary: var(--mdc-snackbar-action-color, #{$mdc-snackbar-action-ink-color});
+}
+
+slot[name=dismiss]::slotted(mwc-icon-button) {
+  --mdc-icon-size: #{$mdc-snackbar-dismiss-icon-size};
+  color: #{$mdc-snackbar-dismiss-ink-color};
+}


### PR DESCRIPTION
Adds rules which apply the correct default color and icon size to `<mwc-button>` and `<mwc-icon-button>` in the `action` and `dismiss` slots.

Adds `--mdc-snackbar-action-color` CSS custom property to override the default color of the action button text.

Before:
![before](https://user-images.githubusercontent.com/48894/62751282-f7727b80-ba17-11e9-9897-9a59eb7930a7.png)

After:
![after](https://user-images.githubusercontent.com/48894/62751285-fb060280-ba17-11e9-930e-72d838cf9237.png)
