### PR TITLE
Allow <mwc-button> open method to be called before firstUpdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Buttons slotted into `<mwc-snackbar>` now render with correct default styles.
   Add `--mdc-snackbar-action-color` CSS custom property to override default
   action button color.
+- Fix bug where `<mwc-snackbar>` `open` method threw if called immediately
+  after construction (before `firstUpdated`).
 
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x


### PR DESCRIPTION
This bit me in testing, and turns out at least one other user has already encountered it. I can imagine wanting to create the element and immediately open it might be a common enough pattern that we should support this.

Fixes https://github.com/material-components/material-components-web-components/issues/308