### PR TITLE
Refactor icon-button to accept SVG or image icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Buttons slotted into `<mwc-snackbar>` now render with correct default styles.
   Add `--mdc-snackbar-action-color` CSS custom property to override default
   action button color.
+- Add support for `<svg>` and `<img>` to `<mwc-icon-button>`
 
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x

--- a/demos/icon-button.html
+++ b/demos/icon-button.html
@@ -58,8 +58,14 @@ limitations under the License.
 
     <h4>SVG Icon, with Color</h4>
     <mwc-icon-button class="color">
-      <svg slot="onIcon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
+      <svg slot="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
       <svg slot="offIcon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z"/><path d="M16.59 7.58L10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
+    </mwc-icon-button>
+
+    <h4>Image Icon</h4>
+    <mwc-icon-button>
+      <img slot="icon" src="https://picsum.photos/id/28/24/24">
+      <img slot="offIcon" src="https://picsum.photos/id/141/24/24?grayscale">
     </mwc-icon-button>
   </main>
 

--- a/demos/icon-button.html
+++ b/demos/icon-button.html
@@ -55,6 +55,12 @@ limitations under the License.
       <mwc-icon-button icon="all_out" offIcon="accessibility"></mwc-icon-button>
       <mwc-icon-button icon="exit_to_app" offIcon="camera"></mwc-icon-button>
     </div>
+
+    <h4>SVG Icon, with Color</h4>
+    <mwc-icon-button class="color">
+      <svg slot="onIcon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
+      <svg slot="offIcon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z"/><path d="M16.59 7.58L10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
+    </mwc-icon-button>
   </main>
 
   <script type="module">

--- a/packages/icon-button/src/icon-button-base.ts
+++ b/packages/icon-button/src/icon-button-base.ts
@@ -27,7 +27,11 @@ export class IconButtonBase extends BaseElement {
 
   @query('.mdc-icon-button') protected mdcRoot!: HTMLElement;
 
-  @query('slot[name="offIcon"]') protected offIconSlot!: HTMLSlotElement;
+  // offIconSlot should have type HTMLSlotElement, but when TypeScript's
+  // emitDecoratorMetadata is enabled, the HTMLSlotElement constructor will
+  // be emitted into the runtime, which will cause an "HTMLSlotElement is
+  // undefined" error in browsers that don't define it (e.g. Edge and IE11).
+  @query('slot[name="offIcon"]') protected offIconSlot!: HTMLElement;
 
   @property({type: String}) label = '';
 
@@ -73,8 +77,8 @@ export class IconButtonBase extends BaseElement {
   }
 
   protected calculateShouldToggle() {
-    this.shouldToggle =
-        !(this.offIcon === '' && !this.offIconSlot.assignedNodes().length);
+    this.shouldToggle = this.offIcon !== '' ||
+        (this.offIconSlot as HTMLSlotElement).assignedNodes().length > 0;
   }
 
   focus() {
@@ -101,12 +105,14 @@ export class IconButtonBase extends BaseElement {
         aria-label="${this.label}"
         ?disabled="${this.disabled}">
         <span class="mdc-icon-button__icon">
-          <slot name="offIcon" @slotchange="${
-        this.calculateShouldToggle}"><i class="material-icons">${
-        this.offIcon}</i></slot>
+          <slot name="offIcon" @slotchange="${this.calculateShouldToggle}">
+            <i class="material-icons">${this.offIcon}</i>
+          </slot>
         </span>
         <span class="mdc-icon-button__icon mdc-icon-button__icon--on">
-          <slot name="onIcon"><i class="material-icons">${this.icon}</i></slot>
+          <slot name="icon">
+            <i class="material-icons">${this.icon}</i>
+          </slot>
         </span>
       </button>`;
   }

--- a/packages/icon-button/src/mwc-icon-button.scss
+++ b/packages/icon-button/src/mwc-icon-button.scss
@@ -17,6 +17,7 @@ limitations under the License.
 
 @import '@material/icon-button/mdc-icon-button.scss';
 @import '@material/mwc-icon/src/_mwc-icon.scss';
+@import '@material/theme/_mixins.scss';
 
 :host {
   display: inline-block;
@@ -30,8 +31,13 @@ limitations under the License.
 // hack for top-app-bar ripple coloring of icon-buttons
 .mdc-ripple-upgraded {
   &:focus::before, &:focus::after {
-    background-color: currentColor;
-    background-color: var(--mdc-theme-on-primary, currentColor);
-    opacity: var(--mdc-icon-button-ripple-opacity, 0.12);
+    @include mdc-theme-prop(background-color, (
+      varname: --mdc-theme-on-primary,
+      fallback: currentColor,
+    ));
+    @include mdc-theme-prop(opacity, (
+      varname: --mdc-icon-button-ripple-opacity,
+      fallback: 0.12,
+    ));
   }
 }

--- a/test/unit/mwc-icon-button.test.js
+++ b/test/unit/mwc-icon-button.test.js
@@ -20,6 +20,7 @@ import {IconButton} from '@material/mwc-icon-button';
 const ICON_SELECTOR = '.mdc-icon-button__icon.mdc-icon-button__icon--on';
 const OFF_ICON_SELECTOR = '.mdc-icon-button__icon:not(.mdc-icon-button__icon--on)';
 
+/** @type {HTMLElement} */
 let element;
 
 suite('mwc-icon-button');
@@ -42,12 +43,12 @@ test('setting `icon` updates the textContent inside <i class="mdc-icon-button__i
   element.icon = icon;
   await element.updateComplete;
   const i = element.shadowRoot.querySelector(ICON_SELECTOR);
-  assert.equal(i.textContent, icon);
+  assert.match(i.textContent, new RegExp(`^\\s*${icon}\\s*$`));
 
   icon = 'menu';
   element.icon = icon;
   await element.updateComplete;
-  assert.equal(i.textContent, icon);
+  assert.match(i.textContent, new RegExp(`^\\s*${icon}\\s*$`));
 });
 
 test('setting `offIcon` updates the textContent inside <i class="mdc-icon-button__icon">', async () => {
@@ -55,12 +56,12 @@ test('setting `offIcon` updates the textContent inside <i class="mdc-icon-button
   element.offIcon = icon;
   await element.updateComplete;
   const i = element.shadowRoot.querySelector(OFF_ICON_SELECTOR);
-  assert.equal(i.textContent, icon);
+  assert.match(i.textContent, new RegExp(`^\\s*${icon}\\s*$`));
 
   icon = 'menu';
   element.offIcon = icon;
   await element.updateComplete;
-  assert.equal(i.textContent, icon);
+  assert.match(i.textContent, new RegExp(`^\\s*${icon}\\s*$`));
 });
 
 test('setting `label` updates the aria-label attribute on the native button element', async () => {
@@ -94,4 +95,64 @@ test('setting `disabled` updates the disabled attribute on the native button ele
   element.disabled = false;
   await element.updateComplete;
   assert.equal(button.hasAttribute('disabled'), false);
+});
+
+test('icon button does not toggle when clicked with only one icon', async () => {
+  element.icon = 'alarm_on';
+  await element.updateComplete;
+  assert.equal(element.on, true);
+  element.mdcRoot.click();
+  await element.updateComplete;
+  assert.equal(element.on, true);
+});
+
+test('icon button toggles when clicked with two icons', async () => {
+  element.icon = 'alarm_on';
+  element.offIcon = 'alarm_off';
+  await element.updateComplete;
+  assert.equal(element.on, false);
+  element.mdcRoot.click();
+  await element.updateComplete;
+  assert.equal(element.on, true);
+});
+
+const svgTemplate = document.createElement('template');
+svgTemplate.innerHTML = `
+<svg slot="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
+<svg slot="offIcon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z"/><path d="M16.59 7.58L10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>`;
+
+test('nodes with `slot=icon` will serve as the on icon', async () => {
+  const icon = svgTemplate.content.querySelector('svg[slot="icon"]').cloneNode(true);
+  element.appendChild(icon);
+  await element.updateComplete;
+  const iconSlot = element.shadowRoot.querySelector('slot[name="icon"]');
+  assert.include(iconSlot.assignedNodes(), icon);
+});
+
+test('nodes with `slot=offIcon` will serve as the off icon', async () => {
+  const icon = svgTemplate.content.querySelector('svg[slot="offIcon"]').cloneNode(true);
+  element.appendChild(icon);
+  await element.updateComplete;
+  const iconSlot = element.shadowRoot.querySelector('slot[name="offIcon"]');
+  assert.include(iconSlot.assignedNodes(), icon);
+});
+
+test('icon-button does not toggle with only slotted icon', async () => {
+  const icon = svgTemplate.content.querySelector('svg[slot="icon"]').cloneNode(true);
+  element.appendChild(icon);
+  await element.updateComplete;
+  assert.equal(element.on, true);
+  element.mdcRoot.click();
+  await element.updateComplete;
+  assert.equal(element.on, true);
+});
+
+test('icon-button toggles with slotted icon and offIcon', async () => {
+  const fragment = svgTemplate.content.cloneNode(true);
+  element.appendChild(fragment);
+  await element.updateComplete;
+  assert.equal(element.on, false);
+  element.mdcRoot.click();
+  await element.updateComplete;
+  assert.equal(element.on, true);
 });


### PR DESCRIPTION
Refactor `<mwc-icon-button>` to have slots, allowing SVG and image icons.

Icon must have `slot="onIcon"`attribute for non-toggling buttons, and an additional Icon with `slot="offIcon"` for toggling buttons

Example:
```html
<mwc-icon-button>
  <img src="on.png" slot="onIcon">
  <img src="off.png" slot="offIcon">
</mwc-icon-button>
```

TODO for PR:
- [x] svg example
- [x] image example
- [x] fix tests

Fixes #156