### PR TITLE
Script to rewrite README images as permanent URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 /test/benchmark/**/*.js
 /test/benchmark/**/*.js.map
 /test/benchmark/**/*.d.ts
+/scripts/tsc-out/

--- a/demos/demo-component.css
+++ b/demos/demo-component.css
@@ -1,4 +1,4 @@
-@import "https://fonts.googleapis.com/css?family=Roboto:300,500,600|Material+Icons";
+@import "https://fonts.googleapis.com/css?family=Roboto:300,400,500|Material+Icons";
 
 body {
   font-family: Roboto, sans-serif;

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Material Components Web Components",
   "license": "Apache-2.0",
   "scripts": {
-    "clean": "del-cli packages/*/node_modules packages/*/package-lock.json && npm run clean:typescript && npm run clean:styles",
+    "clean": "del-cli packages/*/node_modules packages/*/package-lock.json && npm run clean:typescript && npm run clean:styles && npm run clean:scripts",
     "clean:typescript": "npm run build:typescript -- --clean",
     "clean:styles": "del-cli packages/*/src/*-css.ts",
+    "clean:scripts": "del-cli scripts/tsc-out",
     "dev": "polyserve --npm --module-resolution=node",
     "format": "clang-format --version; find . -name '*.ts' | grep -v node_modules | xargs clang-format -style=file -i",
     "lint:imports": "node scripts/check-imports.js",
@@ -20,7 +21,10 @@
     "build:styling": "./scripts/build-styling.sh",
     "build:typescript": "tsc --build packages/**/tsconfig.json",
     "build:tests": "tsc --build test/tsconfig.json && tsc --build test/tsconfig-node.json",
+    "build:scripts": "tsc --project scripts/tsconfig.json",
     "update-gh-pages": "npm run bootstrap && ./scripts/publish-demos.sh",
+    "static-urlify-readme-images": "npm run build:scripts && node scripts/tsc-out/static-urlify-readme-images.js packages/*/README.md",
+    "prepack": "npm run build && npm run static-urlify-readme-images",
     "watch": "npm run bootstrap && node scripts/watcher.js",
     "watch:tests": "npm run bootstrap && tsc --build test/tsconfig.json -w & tsc --build test/tsconfig-node.json -w"
   },

--- a/scripts/static-urlify-readme-images.ts
+++ b/scripts/static-urlify-readme-images.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Our READMEs contain images. But we don't want to publish images in NPM
+// tarballs, because we want to keep them small. This script replaces any
+// relative-path image references in the READMEs with static
+// githubusercontent.com URLs, using the SHA of master.
+
+import {execFileSync} from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import {URL} from 'url';
+
+const mwcRepoRoot = path.resolve(__dirname, '..', '..');
+
+const githubRaw =
+    `https://raw.githubusercontent.com/material-components/material-components-web-components`;
+
+// Matches markdown image syntax like `![description](url "tooltip")`
+const imageRegexp = /(\!\[.*?\]\()([^) ]+)(.*?\))/g;
+
+function isUrl(str: string): boolean {
+  try {
+    new URL(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
+function main() {
+  const fileNames = process.argv.slice(2);
+  if (fileNames.length === 0) {
+    throw new Error('Expected at least one markdown file argument.');
+  }
+
+  // Resolve the SHA for master as of right now. This way the URLs we generate
+  // will be valid and identical forever in this version of the README, whereas
+  // if we used the "master" branch name in the URL, they would become invalid
+  // when we change or move the images.
+  const sha = execFileSync('git', ['rev-parse', '--verify', 'master'], {
+                encoding: 'utf8'
+              }).trim();
+
+  for (const fileName of fileNames) {
+    const markdown = fs.readFileSync(fileName, 'utf8');
+    const updated = markdown.replace(
+        imageRegexp, (_, prefix: string, oldUrl: string, suffix: string) => {
+          if (isUrl(oldUrl)) {
+            // Only transform relative image paths, not fully qualified URLs.
+            return prefix + oldUrl + suffix;
+          }
+          // Absolute path on disk of the image file.
+          const absFilePath = path.resolve(path.dirname(fileName), oldUrl);
+          if (!fs.existsSync(absFilePath)) {
+            throw new Error(`Image file does not exist: ${absFilePath}`);
+          }
+          // Relative URL path from the MWC repo root to the image file.
+          const relUrlPath = path.relative(mwcRepoRoot, absFilePath)
+                                 .replace(path.win32.sep, '/');
+          const newUrl = `${githubRaw}/${sha}/${relUrlPath}`;
+          return prefix + newUrl + suffix
+        });
+    fs.writeFileSync(fileName, updated, 'utf8');
+  }
+}
+
+main();

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "moduleResolution": "node",
+
+    "outDir": "./tsc-out",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "preserveConstEnums": true,
+
+    "lib": [
+      "es2017",
+      "esnext.asynciterable"
+    ],
+
+    "declaration": true,
+    "sourceMap": true,
+    "pretty": true
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}


### PR DESCRIPTION
This way we don't need to publish images in our NPM tarballs (they're already in our `.npmignore` files), but the READMEs will still render with images on npmjs.com, webcomponents.org, etc.

It resolves master to a SHA, and uses that in a raw.githubusercontent.com URL, so that if we change or move images files around, any given version of the README published to NPM won't be
affected.

I made this a prepack script, so that it runs automatically before we publish. (We would not commit those changes, since on GitHub it makes more sense to just the relative path like always).

For example, here's what it did to the FAB README:

![static-image-example](https://user-images.githubusercontent.com/48894/62982242-7254e100-bde0-11e9-84c2-3a73eb465e7d.png)

Also threw in a small fix to our demo CSS Roboto font weights (my mistake from earlier PR).
