### PR TITLE
Fix broken checked property in <mwc-radio>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improve README for `<mwc-button>`
 - Improve README for `<mwc-icon-button>`
 - Split toggling icon button out into `@material/mwc-icon-button-toggle` with tag name `<mwc-icon-button-toggle>`
+- Fix bug where setting the `checked` property on an `<mwc-radio>` did not
+  result in the other radios in the group becoming unchecked.
 
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x

--- a/test/unit/mwc-radio.test.js
+++ b/test/unit/mwc-radio.test.js
@@ -14,22 +14,65 @@
  * limitations under the License.
  */
 
-import {assert} from 'chai';
 import {Radio} from '@material/mwc-radio';
+import {assert} from 'chai';
+import {html, render} from 'lit-html';
 
-let element;
+let container;
 
 suite('mwc-radio');
 
-beforeEach(() => {
-  element = document.createElement('mwc-radio');
-  document.body.appendChild(element);
+before(() => {
+  container = document.createElement('main');
+  document.body.appendChild(container);
 });
 
 afterEach(() => {
-  document.body.removeChild(element);
+  render(html``, container);
+});
+
+after(() => {
+  document.body.removeChild(container);
 });
 
 test('initializes as an mwc-radio', () => {
-  assert.instanceOf(element, Radio);
+  const radio = document.createElement('mwc-radio');
+  container.appendChild(radio);
+  assert.instanceOf(radio, Radio);
+});
+
+test('radio group', async () => {
+  render(
+      html`
+      <mwc-radio name="a"></mwc-group>
+      <mwc-radio name="a"></mwc-group>
+      <mwc-radio name="b"></mwc-group>
+      `,
+      container);
+
+  const [a1, a2, b1] = [...container.querySelectorAll('mwc-radio')];
+  assert.isFalse(a1.checked);
+  assert.isFalse(a2.checked);
+  assert.isFalse(b1.checked);
+
+  a1.checked = true;
+  assert.isTrue(a1.checked);
+  assert.isFalse(a2.checked);
+  assert.isFalse(b1.checked);
+
+  a2.checked = true;
+  assert.isFalse(a1.checked);
+  assert.isTrue(a2.checked);
+  assert.isFalse(b1.checked);
+
+  b1.checked = true;
+  assert.isFalse(a1.checked);
+  assert.isTrue(a2.checked);
+  assert.isTrue(b1.checked);
+
+  a2.checked = false;
+  b1.checked = false;
+  assert.isFalse(a1.checked);
+  assert.isFalse(a2.checked);
+  assert.isFalse(b1.checked);
 });


### PR DESCRIPTION
Previously, we didn't trigger the `SelectionController` (the class that synchronizes radio button groups separated by a shadow root) when the checked property was set, so the previously checked radio in a group was not unchecked when a new one was checked.

This was more complicated than just triggering it from the existing property `@observer`, because that gives us batched async changes (via the `UpdatingElement` updated callback), so we can't reconstruct the order of checked sets correctly. Replaces the observer with a setter that can handle this synchronously.