### PR TITLE
Use SelectionController in <mwc-radio> even without native shadow

### DIFF
--- a/test/unit/mwc-radio.test.js
+++ b/test/unit/mwc-radio.test.js
@@ -41,38 +41,102 @@ test('initializes as an mwc-radio', () => {
   assert.instanceOf(radio, Radio);
 });
 
-test('radio group', async () => {
-  render(
-      html`
-      <mwc-radio name="a"></mwc-group>
-      <mwc-radio name="a"></mwc-group>
-      <mwc-radio name="b"></mwc-group>
-      `,
-      container);
+suite('manages selection groups', () => {
+  test('synchronously', async () => {
+    render(
+        html`
+        <mwc-radio id="a1" name="a"></mwc-group>
+        <mwc-radio id="a2" name="a"></mwc-group>
+        <mwc-radio id="b1" name="b"></mwc-group>
+        `,
+        container);
 
-  const [a1, a2, b1] = [...container.querySelectorAll('mwc-radio')];
-  assert.isFalse(a1.checked);
-  assert.isFalse(a2.checked);
-  assert.isFalse(b1.checked);
+    const [a1, a2, b1] = [...container.querySelectorAll('mwc-radio')];
 
-  a1.checked = true;
-  assert.isTrue(a1.checked);
-  assert.isFalse(a2.checked);
-  assert.isFalse(b1.checked);
+    assert.isFalse(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isFalse(b1.checked);
 
-  a2.checked = true;
-  assert.isFalse(a1.checked);
-  assert.isTrue(a2.checked);
-  assert.isFalse(b1.checked);
+    a2.checked = true;
+    a1.checked = true;
+    assert.isTrue(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isFalse(b1.checked);
 
-  b1.checked = true;
-  assert.isFalse(a1.checked);
-  assert.isTrue(a2.checked);
-  assert.isTrue(b1.checked);
+    a2.checked = true;
+    a1.checked = true;
+    a2.checked = true;
+    assert.isFalse(a1.checked);
+    assert.isTrue(a2.checked);
+    assert.isFalse(b1.checked);
 
-  a2.checked = false;
-  b1.checked = false;
-  assert.isFalse(a1.checked);
-  assert.isFalse(a2.checked);
-  assert.isFalse(b1.checked);
+    a1.checked = true;
+    assert.isTrue(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isTrue(b1.checked);
+
+    b1.checked = true;
+    assert.isFalse(a1.checked);
+    assert.isTrue(a2.checked);
+    assert.isTrue(b1.checked);
+
+    a2.checked = false;
+    b1.checked = false;
+    assert.isFalse(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isFalse(b1.checked);
+  });
+
+  test('after updates settle', async () => {
+    render(
+        html`
+        <mwc-radio id="a1" name="a"></mwc-group>
+        <mwc-radio id="a2" name="a"></mwc-group>
+        <mwc-radio id="b1" name="b"></mwc-group>
+        `,
+        container);
+
+    const radios = [...container.querySelectorAll('mwc-radio')];
+    const [a1, a2, b1] = radios;
+    const allUpdatesComplete = () =>
+        Promise.all(radios.map((radio) => radio.updateComplete));
+
+    await allUpdatesComplete();
+    assert.isFalse(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isFalse(b1.checked);
+
+    a2.checked = true;
+    a1.checked = true;
+    await allUpdatesComplete();
+    assert.isTrue(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isFalse(b1.checked);
+
+    a2.checked = true;
+    a1.checked = true;
+    a2.checked = true;
+    await allUpdatesComplete();
+    assert.isFalse(a1.checked);
+    assert.isTrue(a2.checked);
+    assert.isFalse(b1.checked);
+
+    a1.checked = true;
+    assert.isTrue(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isTrue(b1.checked);
+
+    b1.checked = true;
+    await allUpdatesComplete();
+    assert.isFalse(a1.checked);
+    assert.isTrue(a2.checked);
+    assert.isTrue(b1.checked);
+
+    a2.checked = false;
+    b1.checked = false;
+    await allUpdatesComplete();
+    assert.isFalse(a1.checked);
+    assert.isFalse(a2.checked);
+    assert.isFalse(b1.checked);
+  });
 });


### PR DESCRIPTION
Previously, we did not use the `SelectionController` class when we were not using native shadow roots, because we could rely on the native behavior to manage selection groups for us.

However, since the native `<input>` is not stamped until the async first update, groups were not being managed correctly immediately after construction.

Now, we always use a `SelectionController`. It's probably a little less efficient when we don't have native shadow, and it would be possible to e.g. force an early render to make this work, but I don't think the extra complexity is worth it.

Also expanded the unit test coverage.