### PR TITLE
Fix lit-analyzer warning about property without attribute data.

### DIFF
--- a/packages/ripple/src/mwc-ripple-base.ts
+++ b/packages/ripple/src/mwc-ripple-base.ts
@@ -29,7 +29,7 @@ export class RippleBase extends LitElement {
 
   @property({type: Boolean}) disabled = false;
 
-  @property() protected interactionNode: HTMLElement = this;
+  @property({attribute: false}) protected interactionNode: HTMLElement = this;
 
   connectedCallback() {
     if (this.interactionNode === this) {


### PR DESCRIPTION
Node properties should be attribute:false anyway.