### PR TITLE
Make inner button element stretch to width of host

### DIFF
--- a/packages/button/src/mwc-button.scss
+++ b/packages/button/src/mwc-button.scss
@@ -23,10 +23,14 @@ limitations under the License.
 }
 
 :host {
-  display: inline-block;
+  display: inline-flex;
   outline: none;
 }
 
 :host([disabled]) {
   pointer-events: none;
+}
+
+.mdc-button {
+  flex: auto;
 }


### PR DESCRIPTION
This regressed in the button README PR (https://github.com/material-components/material-components-web-components/pull/366). This reverts that. We want the inner button to expand to the size of the host, so that the user can specify the width of the button.

Found because it broke our internal screenshot test which checks that the button grows when the user sets host width.