### PR TITLE
Standardize format (HTTPS and trailing slash) of MWC links

### DIFF
--- a/packages/icon-button-toggle/README.md
+++ b/packages/icon-button-toggle/README.md
@@ -7,7 +7,7 @@ Toggle buttons can be used to group related options. To emphasize groups of rela
 
 Icons can be used as toggle buttons when they allow selection, or deselection, of a single choice, such as marking an item as a favorite.
 
-For the non-toggling version of this component, see [`<mwc-icon-button>`](https://github.com/material-components/material-components-web-components/tree/master/packages/icon-button/)
+For the non-toggling version of this component, see [`<mwc-icon-button>`](https://github.com/material-components/material-components-web-components/tree/master/packages/icon-button)
 
 [Material Design Guidelines: Toggle Button](https://material.io/design/components/buttons.html#toggle-button)
 

--- a/packages/top-app-bar-fixed/README.md
+++ b/packages/top-app-bar-fixed/README.md
@@ -7,7 +7,7 @@ Fixed Top App Bars are a container for items such as application title, navigati
 
 ![](images/fixed.gif)
 
-For a version of this component that scrolls, see [`<mwc-top-app-bar>`](http://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar)
+For a version of this component that scrolls, see [`<mwc-top-app-bar>`](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar)
 
 [Material Design Guidelines: App Bars: Top](https://material.io/design/components/app-bars-top.html)
 

--- a/packages/top-app-bar/README.md
+++ b/packages/top-app-bar/README.md
@@ -7,7 +7,7 @@ Top App Bars are a container for items such as application title, navigation ico
 
 ![](images/standard.gif)
 
-For a fixed position version of this component, see [`<mwc-top-app-bar-fixed>`](http://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar-fixed)
+For a fixed position version of this component, see [`<mwc-top-app-bar-fixed>`](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar-fixed)
 
 [Material Design Guidelines: App Bars: Top](https://material.io/design/components/app-bars-top.html)
 


### PR DESCRIPTION
This simplifies some automated internal documentation transformations.