### PR TITLE
Changes to Textfield, line-ripple, and floating-label to build internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - **BREAKING** Changed interface to:
   - LineRipple: foundation -> lineRippleFoundation
-  - CharCounter: foundation -> characterCounterFoundation
+  - CharCounter: foundation -> charCounterFoundation
   - FloatingLabel: foundation -> floatingLabelFoundation
 - **BREAKING** added following properties to global `Element` interface
   - lineRippleFoundation?: MDCLineRippleFoundation
-  - characterCounterFoundation?: MDCTextFieldCharacterCounterFoundation
+  - charCounterFoundation?: MDCTextFieldCharacterCounterFoundation
   - floatingLabelFoundationtion?: MDCFloatingLabelFoundation
 - internal fixes to textfield's directives and removed implicit any's
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!--## Unreleased-->
+## Unreleased
+
+- **BREAKING** Changed interface to:
+  - LineRipple: foundation -> lineRippleFoundation
+  - CharCounter: foundation -> characterCounterFoundation
+  - FloatingLabel: foundation -> floatingLabelFoundation
+- **BREAKING** added following properties to global `Element` interface
+  - lineRippleFoundation?: MDCLineRippleFoundation
+  - characterCounterFoundation?: MDCTextFieldCharacterCounterFoundation
+  - floatingLabelFoundationtion?: MDCFloatingLabelFoundation
+- internal fixes to textfield's directives and removed implicit any's
 
 ## [0.8.0] - 2019-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- **BREAKING** Changed interface to:
-  - LineRipple: foundation -> lineRippleFoundation
-  - CharCounter: foundation -> charCounterFoundation
-  - FloatingLabel: foundation -> floatingLabelFoundation
-- **BREAKING** added following properties to global `Element` interface
-  - lineRippleFoundation?: MDCLineRippleFoundation
-  - charCounterFoundation?: MDCTextFieldCharacterCounterFoundation
-  - floatingLabelFoundationtion?: MDCFloatingLabelFoundation
-- internal fixes to textfield's directives and removed implicit any's
+- textfield
+  - **BREAKING** added following properties to global `Element` interface
+    - lineRippleFoundation?: MDCLineRippleFoundation
+    - charCounterFoundation?: MDCTextFieldCharacterCounterFoundation
+    - floatingLabelFoundationtion?: MDCFloatingLabelFoundation
+  - compiles with more strict flags
 
 ## [0.8.0] - 2019-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - textfield
-  - **BREAKING** added following properties to global `Element` interface
-    - lineRippleFoundation?: MDCLineRippleFoundation
-    - charCounterFoundation?: MDCTextFieldCharacterCounterFoundation
-    - floatingLabelFoundationtion?: MDCFloatingLabelFoundation
   - compiles with more strict flags
 
 ## [0.8.0] - 2019-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-
-- textfield
-  - compiles with more strict flags
+<!-- ## Unreleased -->
 
 ## [0.8.0] - 2019-09-03
 

--- a/packages/floating-label/src/mwc-floating-label-directive.ts
+++ b/packages/floating-label/src/mwc-floating-label-directive.ts
@@ -19,7 +19,7 @@ import {MDCFloatingLabelFoundation} from '@material/floating-label/foundation.js
 import {directive, PropertyPart} from 'lit-html';
 
 export interface FloatingLabel extends HTMLLabelElement {
-  foundation: MDCFloatingLabelFoundation;
+  floatingLabelFoundation: MDCFloatingLabelFoundation;
 }
 
 const createAdapter = (labelElement: HTMLElement): MDCFloatingLabelAdapter => {

--- a/packages/line-ripple/src/mwc-line-ripple-directive.ts
+++ b/packages/line-ripple/src/mwc-line-ripple-directive.ts
@@ -19,7 +19,7 @@ import {MDCLineRippleFoundation} from '@material/line-ripple/foundation.js';
 import {directive, PropertyPart} from 'lit-html';
 
 export interface LineRipple extends HTMLElement {
-  foundation: MDCLineRippleFoundation;
+  lineRippleFoundation: MDCLineRippleFoundation;
 }
 
 const createAdapter = (lineElement: HTMLElement): MDCLineRippleAdapter => {

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -23,7 +23,8 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@material/line-ripple": "^3.0.0"
+    "@material/line-ripple": "^3.0.0",
+    "@material/floating-label": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -19,12 +19,9 @@
     "@material/shape": "^3.0.0",
     "@material/textfield": "^3.0.0",
     "@material/theme": "^3.0.0",
+    "@material/line-ripple": "^3.0.0",
     "lit-html": "^1.0.0",
     "tslib": "^1.10.0"
-  },
-  "devDependencies": {
-    "@material/line-ripple": "^3.0.0",
-    "@material/floating-label": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -22,6 +22,9 @@
     "lit-html": "^1.0.0",
     "tslib": "^1.10.0"
   },
+  "devDependencies": {
+    "@material/line-ripple": "^3.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/textfield/src/character-counter/mwc-character-counter-directive.ts
+++ b/packages/textfield/src/character-counter/mwc-character-counter-directive.ts
@@ -19,7 +19,7 @@ import {MDCTextFieldCharacterCounterFoundation} from '@material/textfield/charac
 import {directive, PropertyPart} from 'lit-html';
 
 export interface CharacterCounter extends HTMLElement {
-  foundation: MDCTextFieldCharacterCounterFoundation;
+  charCounterFoundation: MDCTextFieldCharacterCounterFoundation;
 }
 
 const createAdapter =

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -16,6 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-notched-outline';
 
+import {MDCFloatingLabelFoundation} from '@material/floating-label/foundation.js';
 import {MDCLineRippleFoundation} from '@material/line-ripple/foundation.js';
 import {addHasRemoveClass, classMap, FormElement, html, property, PropertyValues, query, TemplateResult} from '@material/mwc-base/form-element.js';
 import {floatingLabel, FloatingLabel} from '@material/mwc-floating-label';
@@ -31,16 +32,26 @@ import {characterCounter, CharacterCounter} from './character-counter/mwc-charac
 // must be done to get past lit-analyzer checks
 declare global {
   interface Element {
-    foundation?: MDCLineRippleFoundation|MDCTextFieldCharacterCounterFoundation;
+    floatingLabelFoundation?: MDCFloatingLabelFoundation;
+    lineRippleFoundation?: MDCLineRippleFoundation;
+    charCounterFoundation?: MDCTextFieldCharacterCounterFoundation;
   }
 }
 
-type ValidityStateProp =
-    'badInput'|'customError'|'patternMismatch'|'rangeOverflow'|'rangeUnderflow'|
-    'stepMismatch'|'tooLong'|'tooShort'|'typeMismatch'|'valid'|'valueMissing';
-type CustomValidityState = {
-  [prop in ValidityStateProp]: boolean;
-};
+interface CustomValidityState {
+  badInput: boolean;
+  customError: boolean;
+  patternMismatch: boolean;
+  rangeOverflow: boolean;
+  rangeUnderflow: boolean;
+  stepMismatch: boolean;
+  tooLong: boolean;
+  tooShort: boolean;
+  typeMismatch: boolean;
+  valid: boolean;
+  valueMissing: boolean;
+}
+
 
 const passiveEvents = ['touchstart', 'touchmove', 'scroll', 'mousewheel'];
 
@@ -50,7 +61,7 @@ const createValidityObj =
 
       // eslint-disable-next-line guard-for-in
       for (const propName in customValidity) {
-        objectifiedCustomValidity[propName as ValidityStateProp] =
+        objectifiedCustomValidity[propName as keyof CustomValidityState] =
             customValidity[propName as keyof ValidityState];
       }
 
@@ -227,7 +238,7 @@ export abstract class TextFieldBase extends FormElement {
     let labelTemplate: TemplateResult|string = '';
     if (this.label) {
       labelTemplate = html`
-        <label .foundation=${floatingLabel()} for="text-field">
+        <label .floatingLabelFoundation=${floatingLabel()} for="text-field">
           ${this.label}
         </label>
       `;
@@ -245,14 +256,14 @@ export abstract class TextFieldBase extends FormElement {
     let labelTemplate: TemplateResult|string = '';
     if (this.label && !this.fullWidth) {
       labelTemplate = html`
-      <label .foundation=${floatingLabel()} for="text-field">
+      <label .floatingLabelFoundation=${floatingLabel()} for="text-field">
         ${this.label}
       </label>`;
     }
 
     return html`
       ${labelTemplate}
-      <div .foundation=${lineRipple()}></div>
+      <div .lineRippleFoundation=${lineRipple()}></div>
     `;
   }
 
@@ -265,7 +276,8 @@ export abstract class TextFieldBase extends FormElement {
 
     let charCounterTemplate: TemplateResult|string = '';
     if (this.charCounter) {
-      charCounterTemplate = html`<div .foundation=${characterCounter()}></div>`;
+      charCounterTemplate = html`
+        <div .characterCounterFoundation=${characterCounter()}></div>`;
     }
     return html`
       <div class="mdc-text-field-helper-line">
@@ -335,7 +347,7 @@ export abstract class TextFieldBase extends FormElement {
     }
     this.mdcFoundation = new this.mdcFoundationClass(this.createAdapter(), {
       characterCounter: this.charCounterElement ?
-          this.charCounterElement.foundation :
+          this.charCounterElement.charCounterFoundation :
           undefined
     });
     this.mdcFoundation.init();
@@ -391,14 +403,16 @@ export abstract class TextFieldBase extends FormElement {
 
   protected getLabelAdapterMethods(): MDCTextFieldLabelAdapter {
     return {
-      floatLabel: (shouldFloat: boolean) =>
-          this.labelElement && this.labelElement.foundation.float(shouldFloat),
+      floatLabel: (shouldFloat: boolean) => this.labelElement &&
+          this.labelElement.floatingLabelFoundation.float(shouldFloat),
       getLabelWidth: () => {
-        return this.labelElement ? this.labelElement.foundation.getWidth() : 0;
+        return this.labelElement ?
+            this.labelElement.floatingLabelFoundation.getWidth() :
+            0;
       },
       hasLabel: () => Boolean(this.labelElement),
-      shakeLabel: (shouldShake: boolean) =>
-          this.labelElement && this.labelElement.foundation.shake(shouldShake),
+      shakeLabel: (shouldShake: boolean) => this.labelElement &&
+          this.labelElement.floatingLabelFoundation.shake(shouldShake),
     };
   }
 
@@ -406,17 +420,18 @@ export abstract class TextFieldBase extends FormElement {
     return {
       activateLineRipple: () => {
         if (this.lineRippleElement) {
-          this.lineRippleElement.foundation.activate();
+          this.lineRippleElement.lineRippleFoundation.activate();
         }
       },
       deactivateLineRipple: () => {
         if (this.lineRippleElement) {
-          this.lineRippleElement.foundation.deactivate();
+          this.lineRippleElement.lineRippleFoundation.deactivate();
         }
       },
       setLineRippleTransformOrigin: (normalizedX: number) => {
         if (this.lineRippleElement) {
-          this.lineRippleElement.foundation.setRippleCenter(normalizedX);
+          this.lineRippleElement.lineRippleFoundation.setRippleCenter(
+              normalizedX);
         }
       },
     };

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -57,10 +57,24 @@ const passiveEvents = ['touchstart', 'touchmove', 'scroll', 'mousewheel'];
 
 const createValidityObj =
     (customValidity: Partial<ValidityState> = {}): ValidityState => {
+      /*
+       * We need to make ValidityState an object because it is readonly and
+       * we cannot use the spread operator. Also, we don't export
+       * `CustomValidityState` because it is a leaky implementation and the user
+       * already has access to `ValidityState` in lib.dom.ts. Also an interface
+       * {a: Type} can be casted to {readonly a: Type} so passing any object
+       * should be fine.
+       */
       const objectifiedCustomValidity: Partial<CustomValidityState> = {};
 
       // eslint-disable-next-line guard-for-in
       for (const propName in customValidity) {
+        /*
+         * Casting is needed because ValidityState's props are all readonly and
+         * thus cannot be set on `onjectifiedCustomValidity`. In the end, the
+         * interface is the same as ValidityState (but not readonly), but the
+         * function signature casts the output to ValidityState (thus readonly).
+         */
         objectifiedCustomValidity[propName as keyof CustomValidityState] =
             customValidity[propName as keyof ValidityState];
       }
@@ -277,7 +291,7 @@ export abstract class TextFieldBase extends FormElement {
     let charCounterTemplate: TemplateResult|string = '';
     if (this.charCounter) {
       charCounterTemplate = html`
-        <div .characterCounterFoundation=${characterCounter()}></div>`;
+        <div .charCounterFoundation=${characterCounter()}></div>`;
     }
     return html`
       <div class="mdc-text-field-helper-line">

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -38,19 +38,9 @@ declare global {
   }
 }
 
-interface CustomValidityState {
-  badInput: boolean;
-  customError: boolean;
-  patternMismatch: boolean;
-  rangeOverflow: boolean;
-  rangeUnderflow: boolean;
-  stepMismatch: boolean;
-  tooLong: boolean;
-  tooShort: boolean;
-  typeMismatch: boolean;
-  valid: boolean;
-  valueMissing: boolean;
-}
+type CustomValidityState = {
+  -readonly[P in keyof ValidityState]: ValidityState[P]
+};
 
 
 const passiveEvents = ['touchstart', 'touchmove', 'scroll', 'mousewheel'];

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -16,25 +16,42 @@ limitations under the License.
 */
 import '@material/mwc-notched-outline';
 
+import {MDCLineRippleFoundation} from '@material/line-ripple/foundation.js';
 import {addHasRemoveClass, classMap, FormElement, html, property, PropertyValues, query, TemplateResult} from '@material/mwc-base/form-element.js';
 import {floatingLabel, FloatingLabel} from '@material/mwc-floating-label';
 import {lineRipple, LineRipple} from '@material/mwc-line-ripple';
 import {NotchedOutline} from '@material/mwc-notched-outline';
 import {MDCTextFieldAdapter, MDCTextFieldInputAdapter, MDCTextFieldLabelAdapter, MDCTextFieldLineRippleAdapter, MDCTextFieldOutlineAdapter, MDCTextFieldRootAdapter} from '@material/textfield/adapter.js';
+import {MDCTextFieldCharacterCounterFoundation} from '@material/textfield/character-counter/foundation.js';
 import MDCTextFieldFoundation from '@material/textfield/foundation.js';
 import {ifDefined} from 'lit-html/directives/if-defined.js';
 
 import {characterCounter, CharacterCounter} from './character-counter/mwc-character-counter-directive.js';
 
+// must be done to get past lit-analyzer checks
+declare global {
+  interface Element {
+    foundation?: MDCLineRippleFoundation|MDCTextFieldCharacterCounterFoundation;
+  }
+}
+
+type ValidityStateProp =
+    'badInput'|'customError'|'patternMismatch'|'rangeOverflow'|'rangeUnderflow'|
+    'stepMismatch'|'tooLong'|'tooShort'|'typeMismatch'|'valid'|'valueMissing';
+type CustomValidityState = {
+  [prop in ValidityStateProp]: boolean;
+};
+
 const passiveEvents = ['touchstart', 'touchmove', 'scroll', 'mousewheel'];
 
 const createValidityObj =
     (customValidity: Partial<ValidityState> = {}): ValidityState => {
-      const objectifiedCustomValidity: Partial<ValidityState> = {};
+      const objectifiedCustomValidity: Partial<CustomValidityState> = {};
 
       // eslint-disable-next-line guard-for-in
       for (const propName in customValidity) {
-        objectifiedCustomValidity[propName] = customValidity[propName];
+        objectifiedCustomValidity[propName as ValidityStateProp] =
+            customValidity[propName as keyof ValidityState];
       }
 
       return {


### PR DESCRIPTION
- **INTERNAL BREAKING** Changed interface to:
  - LineRipple: foundation -> lineRippleFoundation
  - CharCounter: foundation -> characterCounterFoundation
  - FloatingLabel: foundation -> floatingLabelFoundation
- **INTERNAL BREAKING** added following properties to global `Element` interface
  - lineRippleFoundation?: MDCLineRippleFoundation
  - characterCounterFoundation?: MDCTextFieldCharacterCounterFoundation
  - floatingLabelFoundationtion?: MDCFloatingLabelFoundation
- Renamed textfield's directive applications
- Removed implicit any's in textfield caused by ValidityState

related #454 