### PR TITLE
Fix focus button textfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- mwc-button
+  - Added custom focus and blur functions that cause ripple
+- mwc-textfield
+  - Focus function now focuses the native input and activates the caret
+  - Blur appropriately blurs the input
 
 ## [0.8.0] - 2019-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- mwc-button
-  - Added custom focus and blur functions that cause ripple
-- mwc-textfield
-  - Focus function now focuses the native input and activates the caret
-  - Blur appropriately blurs the input
+### Changed
+
+- **BREAKING:** Added custom `.focus()` and `.blur()` functions to mwc-button
+  that cause the button to ripple as when tab focusing.
+- **BREAKING:** mwc-textfield's custom `.focus()` function will now call
+  `.focus()` on the native internal input causing the caret to appear instead of
+  just forcing focus styles to appear.
+- **BREAKING:** mwc-textfield's custom `.blur()` function will now call
+  `.blur()` on the native internal input instead of just forcing focus styles to
+  disapprear.
 
 ## [0.8.0] - 2019-09-03
 

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -15,6 +15,9 @@
     "lit-html": "^1.0.0",
     "tslib": "^1.10.0"
   },
+  "devDependencies": {
+    "@material/ripple": "^3.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -11,12 +11,10 @@
   "dependencies": {
     "@material/base": "^3.0.0",
     "@material/dom": "^3.1.0",
+    "@material/ripple": "^3.0.0",
     "lit-element": "^2.2.1",
     "lit-html": "^1.0.0",
     "tslib": "^1.10.0"
-  },
-  "devDependencies": {
-    "@material/ripple": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/base/src/form-element.ts
+++ b/packages/base/src/form-element.ts
@@ -16,9 +16,10 @@ limitations under the License.
 */
 
 import {BaseElement} from './base-element';
+import {MDCRippleFoundation} from '@material/ripple/foundation.js'
 export * from './base-element';
 
-export interface RippleSurface {
+export interface RippleSurface extends MDCRippleFoundation {
   activate(): void;
   deactivate(): void;
 }

--- a/packages/base/src/form-element.ts
+++ b/packages/base/src/form-element.ts
@@ -15,8 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {BaseElement} from './base-element';
 import {MDCRippleFoundation} from '@material/ripple/foundation.js'
+
+import {BaseElement} from './base-element';
+
 export * from './base-element';
 
 export interface RippleSurface extends MDCRippleFoundation {

--- a/packages/base/src/form-element.ts
+++ b/packages/base/src/form-element.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {MDCRippleFoundation} from '@material/ripple/foundation.js'
+import {MDCRippleFoundation} from '@material/ripple/foundation.js';
 
 import {BaseElement} from './base-element';
 

--- a/packages/button/src/mwc-button-base.ts
+++ b/packages/button/src/mwc-button-base.ts
@@ -14,7 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {classMap, html, LitElement, property} from '@material/mwc-base/base-element';
+import {classMap, html, LitElement, property, query} from '@material/mwc-base/base-element';
+import {HTMLElementWithRipple} from '@material/mwc-base/form-element';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 
 export class ButtonBase extends LitElement {
@@ -34,8 +35,32 @@ export class ButtonBase extends LitElement {
 
   @property() label = '';
 
+  @query('#button') buttonElement!: HTMLElementWithRipple;
+
   protected createRenderRoot() {
     return this.attachShadow({mode: 'open', delegatesFocus: true});
+  }
+
+  focus() {
+    const buttonElement = this.buttonElement;
+    if (buttonElement) {
+      const ripple = buttonElement.ripple;
+      if (ripple) {
+        ripple.handleFocus();
+        buttonElement.focus();
+      }
+    }
+  }
+
+  blur() {
+    const buttonElement = this.buttonElement;
+    if (buttonElement) {
+      const ripple = buttonElement.ripple;
+      if (ripple) {
+        ripple.handleBlur();
+        buttonElement.blur();
+      }
+    }
   }
 
   protected render() {
@@ -48,7 +73,7 @@ export class ButtonBase extends LitElement {
     const mdcButtonIcon =
         html`<span class="material-icons mdc-button__icon">${this.icon}</span>`;
     return html`
-      <button .ripple="${ripple({
+      <button id="button" .ripple="${ripple({
       unbounded: false
     })}"
           class="mdc-button ${classMap(classes)}"

--- a/packages/button/src/mwc-button-base.ts
+++ b/packages/button/src/mwc-button-base.ts
@@ -47,8 +47,9 @@ export class ButtonBase extends LitElement {
       const ripple = buttonElement.ripple;
       if (ripple) {
         ripple.handleFocus();
-        buttonElement.focus();
       }
+
+      buttonElement.focus();
     }
   }
 
@@ -58,8 +59,9 @@ export class ButtonBase extends LitElement {
       const ripple = buttonElement.ripple;
       if (ripple) {
         ripple.handleBlur();
-        buttonElement.blur();
       }
+
+      buttonElement.blur();
     }
   }
 

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -175,6 +175,7 @@ export abstract class TextFieldBase extends FormElement {
   focus() {
     const focusEvt = new FocusEvent('focus');
     this.formElement.dispatchEvent(focusEvt);
+    this.formElement.focus();
   }
 
   blur() {

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -181,6 +181,7 @@ export abstract class TextFieldBase extends FormElement {
   blur() {
     const blurEvt = new FocusEvent('blur');
     this.formElement.dispatchEvent(blurEvt);
+    this.formElement.blur();
   }
 
   render() {

--- a/test/src/unit/mwc-button.test.ts
+++ b/test/src/unit/mwc-button.test.ts
@@ -16,11 +16,12 @@
 
 import {Button} from '@material/mwc-button';
 import {html} from 'lit-html';
-import {fixture, TestFixture, rafPromise} from '../util/helpers';
+
+import {fixture, rafPromise, TestFixture} from '../util/helpers';
 
 const ICON_SELECTOR = '.mdc-button__icon';
 
-const basic = html `
+const basic = html`
   <mwc-button>this is a button</mwc-button>
 `;
 
@@ -81,7 +82,8 @@ suite('mwc-button', () => {
 
     test('focus fn highlights and blurs', async () => {
       const focusedClass = 'mdc-ripple-upgraded--background-focused';
-      const nativeButton = element.shadowRoot!.querySelector('#button') as HTMLButtonElement;
+      const nativeButton =
+          element.shadowRoot!.querySelector('#button') as HTMLButtonElement;
       expect(nativeButton.classList.contains(focusedClass)).to.be.false;
       element.focus();
       await element.requestUpdate();

--- a/test/src/unit/mwc-button.test.ts
+++ b/test/src/unit/mwc-button.test.ts
@@ -15,52 +15,86 @@
  */
 
 import {Button} from '@material/mwc-button';
+import {html} from 'lit-html';
+import {fixture, TestFixture, rafPromise} from '../util/helpers';
 
 const ICON_SELECTOR = '.mdc-button__icon';
 
+const basic = html `
+  <mwc-button>this is a button</mwc-button>
+`;
 
 suite('mwc-button', () => {
-  let element;
+  let element: Button;
 
-  setup(() => {
-    element = document.createElement('mwc-button');
-    document.body.appendChild(element);
-  });
+  suite('basic', () => {
+    setup(() => {
+      element = document.createElement('mwc-button');
+      document.body.appendChild(element);
+    });
 
-  teardown(() => {
-    document.body.removeChild(element);
-  });
+    teardown(() => {
+      document.body.removeChild(element);
+    });
 
-  test('initializes as an mwc-button', () => {
-    assert.instanceOf(element, Button);
-  });
+    test('initializes as an mwc-button', () => {
+      assert.instanceOf(element, Button);
+    });
 
-  test(
-      'get/set disabled updates the disabled property on the native button element',
-      async () => {
-        element.disabled = true;
-        await element.updateComplete;
-        const button = element.shadowRoot.querySelector('button');
-        assert.equal(button.hasAttribute('disabled'), true);
+    test(
+        'get/set disabled updates the disabled property on the native button element',
+        async () => {
+          element.disabled = true;
+          await element.updateComplete;
+          const button = element.shadowRoot!.querySelector('button')!;
+          assert.equal(button.hasAttribute('disabled'), true);
 
-        element.disabled = false;
-        await element.updateComplete;
-        assert.equal(button.hasAttribute('disabled'), false);
-      });
+          element.disabled = false;
+          await element.updateComplete;
+          assert.equal(button.hasAttribute('disabled'), false);
+        });
 
-  test('setting `icon` adds an icon to the button', async () => {
-    await element.updateComplete;
-    let icon = element.shadowRoot.querySelector(ICON_SELECTOR);
-    assert.equal(icon, null);
+    test('setting `icon` adds an icon to the button', async () => {
+      await element.updateComplete;
+      let icon = element.shadowRoot!.querySelector(ICON_SELECTOR);
+      assert.equal(icon, null);
 
-    element.icon = 'check';
-    await element.updateComplete;
-    icon = element.shadowRoot.querySelector(ICON_SELECTOR);
-    assert.instanceOf(icon, Element);
+      element.icon = 'check';
+      await element.updateComplete;
+      icon = element.shadowRoot!.querySelector(ICON_SELECTOR);
+      assert.instanceOf(icon, Element);
 
-    element.icon = undefined;
-    await element.updateComplete;
-    icon = element.shadowRoot.querySelector(ICON_SELECTOR);
-    assert.equal(icon, null);
-  });
+      element.icon = '';
+      await element.updateComplete;
+      icon = element.shadowRoot!.querySelector(ICON_SELECTOR);
+      assert.equal(icon, null);
+    });
+  })
+
+  suite('focus', () => {
+    let fixt: TestFixture;
+    let element: Button;
+    setup(async () => {
+      fixt = await fixture(basic);
+      element = fixt.root.firstElementChild as Button;
+    });
+
+    test('focus fn highlights and blurs', async () => {
+      const focusedClass = 'mdc-ripple-upgraded--background-focused';
+      const nativeButton = element.shadowRoot!.querySelector('#button') as HTMLButtonElement;
+      expect(nativeButton.classList.contains(focusedClass)).to.be.false;
+      element.focus();
+      await element.requestUpdate();
+      await rafPromise();
+      expect(nativeButton.classList.contains(focusedClass)).to.be.true;
+      element.blur();
+      await element.requestUpdate();
+      await rafPromise();
+      expect(nativeButton.classList.contains(focusedClass)).to.be.false;
+    });
+
+    teardown(async () => {
+      fixt.remove();
+    })
+  })
 });

--- a/test/src/util/helpers.ts
+++ b/test/src/util/helpers.ts
@@ -163,3 +163,7 @@ export const measureFixtureCreation = async (
 
   return renderTargetRoot;
 }
+
+export const rafPromise = async () => new Promise(res => {
+  requestAnimationFrame(res);
+});

--- a/test/src/util/helpers.ts
+++ b/test/src/util/helpers.ts
@@ -114,9 +114,10 @@ const defaultMeasureOpts = {
   numRenders: 10,
 }
 
-export const measureFixtureCreation = async (
-    template: TemplateResult,
-    options?: Partial<MeasureFixtureCreationOpts>) => {
+export const measureFixtureCreation =
+    async (
+        template: TemplateResult,
+        options?: Partial<MeasureFixtureCreationOpts>) => {
   const opts: MeasureFixtureCreationOpts = {...defaultMeasureOpts, ...options};
   const templates = new Array<TemplateResult>(opts.numRenders).fill(template);
   const renderContainer = document.createElement('div');


### PR DESCRIPTION
- mwc-button
  - Added custom focus and blur functions that cause ripple
- mwc-textfield
  - Focus function now focuses the native input and activates the caret
  - Blur appropriately blurs the input