### PR TITLE
Bump wicg-inert version to ensure module field exists for bundling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- `<mwc-drawer>` can now be used with Rollup (via version bump to pick up
+  [WICG/inert#135](https://github.com/WICG/inert/pull/135)).
 
 ## [0.8.0] - 2019-09-03
 

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -20,7 +20,7 @@
     "@material/mwc-base": "^0.8.0",
     "blocking-elements": "^0.1.0",
     "tslib": "^1.10.0",
-    "wicg-inert": "^2.1.3"
+    "wicg-inert": "^2.2.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes https://github.com/material-components/material-components-web-components/issues/257