### PR TITLE
add select() to text fields

### DIFF
--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -186,6 +186,10 @@ export abstract class TextFieldBase extends FormElement {
     this.formElement.blur();
   }
 
+  select() {
+    this.formElement.select();
+  }
+
   render() {
     const classes = {
       'mdc-text-field--disabled': this.disabled,

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -170,6 +170,14 @@ export abstract class TextFieldBase extends FormElement {
     return this.formElement.willValidate;
   }
 
+  get selectionStart(): number|null {
+    return this.formElement.selectionStart;
+  }
+
+  get selectionEnd(): number|null {
+    return this.formElement.selectionEnd;
+  }
+
   validityTransform:
       ((value: string,
         nativeValidity: ValidityState) => Partial<ValidityState>)|null = null;
@@ -188,6 +196,13 @@ export abstract class TextFieldBase extends FormElement {
 
   select() {
     this.formElement.select();
+  }
+
+  setSelectionRange(
+      selectionStart: number, selectionEnd: number,
+      selectionDirection?: 'forward'|'backward'|'none') {
+    this.formElement.setSelectionRange(
+        selectionStart, selectionEnd, selectionDirection);
   }
 
   render() {

--- a/test/src/unit/mwc-textfield.test.ts
+++ b/test/src/unit/mwc-textfield.test.ts
@@ -203,4 +203,27 @@ suite('mwc-textfield:', () => {
       }
     });
   });
+
+  suite('select', () => {
+    let element: TextField;
+
+    setup(async () => {
+      fixt = await fixture(basic);
+
+      element = fixt.root.querySelector('mwc-textfield')!;
+    });
+
+    test('selects the input text', () => {
+      const input = element.shadowRoot!.querySelector('input');
+
+      element.select();
+      assert.equal(element.shadowRoot!.activeElement, input);
+    });
+
+    teardown(() => {
+      if (fixt) {
+        fixt.remove();
+      }
+    });
+  });
 });

--- a/test/src/unit/mwc-textfield.test.ts
+++ b/test/src/unit/mwc-textfield.test.ts
@@ -221,7 +221,7 @@ suite('mwc-textfield:', () => {
       element.select();
 
       assert.equal(input.selectionStart, 0);
-      assert.equal(input.selectionEnd, 5);
+      assert.equal(input.selectionEnd, 6);
     });
 
     teardown(() => {

--- a/test/src/unit/mwc-textfield.test.ts
+++ b/test/src/unit/mwc-textfield.test.ts
@@ -214,10 +214,14 @@ suite('mwc-textfield:', () => {
     });
 
     test('selects the input text', () => {
-      const input = element.shadowRoot!.querySelector('input');
+      const input = element.shadowRoot!.querySelector('input')!;
+
+      input.value = 'foobar';
 
       element.select();
-      assert.equal(element.shadowRoot!.activeElement, input);
+
+      assert.equal(input.selectionStart, 0);
+      assert.equal(input.selectionEnd, 5);
     });
 
     teardown(() => {

--- a/test/src/unit/mwc-textfield.test.ts
+++ b/test/src/unit/mwc-textfield.test.ts
@@ -240,10 +240,12 @@ suite('mwc-textfield:', () => {
       element = fixt.root.querySelector('mwc-textfield')!;
     });
 
-    test('sets correct selection', () => {
+    test('sets correct selection', async () => {
       const input = element.shadowRoot!.querySelector('input')!;
 
       element.value = 'one two three';
+      await element.updateComplete;
+
       element.setSelectionRange(4, 6);
 
       assert.equal(input.selectionStart, 4);

--- a/test/src/unit/mwc-textfield.test.ts
+++ b/test/src/unit/mwc-textfield.test.ts
@@ -226,4 +226,32 @@ suite('mwc-textfield:', () => {
       }
     });
   });
+
+  suite('setSelectionRange', () => {
+    let element: TextField;
+
+    setup(async () => {
+      fixt = await fixture(basic);
+
+      element = fixt.root.querySelector('mwc-textfield')!;
+    });
+
+    test('sets correct selection', () => {
+      const input = element.shadowRoot!.querySelector('input')!;
+
+      element.value = 'one two three';
+      element.setSelectionRange(4, 6);
+
+      assert.equal(input.selectionStart, 4);
+      assert.equal(input.selectionEnd, 6);
+      assert.equal(element.selectionStart, 4);
+      assert.equal(element.selectionEnd, 6);
+    });
+
+    teardown(() => {
+      if (fixt) {
+        fixt.remove();
+      }
+    });
+  });
 });


### PR DESCRIPTION
pretty simple one

fixes #461.
fixes #68.

LMK if you're up for merging it. also if you think we need to dispatch an event or anything alongside calling `select()` (as thats what focus/blur methods do).

cc @azakus @e111077 