### PR TITLE
fix extra spacing – older browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `lit-element` or `lit-html` APIs (e.g. `LitElement`, `customElement`,
   `classMap`). Users should import directly from the `lit-element` and
   `lit-html` modules instead.
+- **BREAKING** `mwc-textfield` and `mwc-textarea` will now update their `.value`
+  on the native `input`'s `input` event instead of `change`.
 
 ### Fixed
 
 - `<mwc-drawer>` can now be used with Rollup (via version bump to pick up
   [WICG/inert#135](https://github.com/WICG/inert/pull/135)).
+- `<mwc-textfield>` and `<mwc-textarea>` will now have the same height between
+  their filled and outlined variants with helper text on older browsers.
+- `mwc-textfield[required]` and `mwc-textarea[required]` will now have their
+  required asterisk colored correctly when customized.
 
 
 ## [0.8.0] - 2019-09-03

--- a/packages/notched-outline/src/mwc-notched-outline.scss
+++ b/packages/notched-outline/src/mwc-notched-outline.scss
@@ -53,11 +53,6 @@ limitations under the License.
 
 .mdc-notched-outline--upgraded ::slotted(.mdc-floating-label--float-above) {
   max-width: calc(100% / .75);
-
-  @include mdc-theme-prop(color, (
-    varname: --mdc-theme-primary,
-    fallback: $mdc-theme-primary
-  ));
 }
 
 .mdc-notched-outline__leading {

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -46,7 +46,6 @@ limitations under the License.
     varname: --mdc-text-field-filled-border-radius,
     fallback: mdc-shape-mask-radius(mdc-shape-prop-value(small), 1 1 0 0)
   ));
-
 }
 
 mwc-notched-outline {
@@ -81,7 +80,14 @@ mwc-notched-outline {
       --mdc-notched-outline-border-color: var(--mdc-text-field-focused-label-color, var(--mdc-theme-primary, #{$mdc-text-field-focused-label-color}));
     }
 
-    .mdc-floating-label, .mdc-floating-label::after {
+    .mdc-floating-label {
+      @include mdc-theme-prop(color, (
+        varname: --mdc-theme-primary,
+        fallback: $mdc-theme-primary
+      ));
+    }
+
+    @include mdc-required-text-field-label-asterisk_ {
       @include mdc-theme-prop(color, (
         varname: --mdc-theme-primary,
         fallback: $mdc-theme-primary

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -38,6 +38,8 @@ limitations under the License.
 }
 
 .mdc-text-field {
+  display: flex;
+
   width: 100%;
 
   @include mdc-theme-prop(border-radius, (


### PR DESCRIPTION
fixes #468 

This happens on older browsers. Not necessarily shady DOM. basically changed the root element from `display: flex-inline` to `display: flex`. Didn't seem to change anything adversely. Will check with internal screenshot testing after github approval.

Before:

![image](https://user-images.githubusercontent.com/5981958/65290316-a1f3b900-db03-11e9-9978-a0d0f063a995.png)


After:

![image](https://user-images.githubusercontent.com/5981958/65290321-a7510380-db03-11e9-8795-13d3a6e8df0a.png)

also fixes color of `mwc-textfield[required]` label asterisk when focused annd themed