### PR TITLE
Bump wicg-inert polyfill to 3.0.0

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -18,7 +18,7 @@
     "@material/dialog": "^3.0.0",
     "blocking-elements": "^0.1.0",
     "tslib": "^1.10.0",
-    "wicg-inert": "^2.1.3",
+    "wicg-inert": "^3.0.0",
     "lit-element": "^2.2.1",
     "lit-html": "^1.1.2"
   },

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -22,7 +22,7 @@
     "lit-element": "^2.2.1",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0",
-    "wicg-inert": "^2.2.0"
+    "wicg-inert": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This version has a "module" field that resolves to ES2015 code (uses native ES2015 classes instead of transpiled). See https://github.com/WICG/inert/issues/136 for more context.