### PR TITLE
[mwc-textfield] call setValue when value changes

### DIFF
--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -250,6 +250,11 @@ export abstract class TextFieldBase extends FormElement {
     if (maxLengthBecameDefined || maxLengthBecameUndefined) {
       this.createFoundation();
     }
+
+    if (changedProperties.has('value') &&
+        changedProperties.get('value') !== undefined) {
+      this.mdcFoundation.setValue(this.value);
+    }
   }
 
   protected renderInput() {

--- a/packages/textfield/src/test/mwc-textfield.test.ts
+++ b/packages/textfield/src/test/mwc-textfield.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import {cssClasses as floatingClasses} from '@material/floating-label/constants';
 import {FloatingLabel} from '@material/mwc-floating-label';
 import {TextField} from '@material/mwc-textfield';
 import {cssClasses} from '@material/textfield/constants';
@@ -55,6 +56,10 @@ const makeOutlined = (isHidden: boolean) => html`
       class="${isHidden ? 'hidden' : ''}"
       value="some value to notch label">
   </mwc-textfield>
+`;
+
+const withLabel = html`
+  <mwc-textfield label="a label"></mwc-textfield>
 `;
 
 const isUiInvalid = (element: TextField) => {
@@ -489,6 +494,36 @@ suite('mwc-textfield:', () => {
       if (fixt) {
         fixt.remove();
       }
+    });
+  });
+
+  suite('label', () => {
+    let element: TextField;
+
+    setup(async () => {
+      fixt = await fixture(withLabel);
+      element = fixt.root.querySelector('mwc-textfield')!;
+      await element.updateComplete;
+    });
+
+    teardown(() => {
+      if (fixt) {
+        fixt.remove();
+      }
+    });
+
+    test('label floats when value is set', async () => {
+      const floatingLabel =
+          element.shadowRoot!.querySelector('label') as FloatingLabel;
+
+      assert.isFalse(
+          floatingLabel.classList.contains(floatingClasses.LABEL_FLOAT_ABOVE));
+
+      element.value = 'foo bar';
+      await element.updateComplete;
+
+      assert.isTrue(
+          floatingLabel.classList.contains(floatingClasses.LABEL_FLOAT_ABOVE));
     });
   });
 });


### PR DESCRIPTION
Fixes #515

If we call `setValue` on the foundation when the value changes, all the base logic like positioning the floating label happens. there's already a check in the foundation for if the value is equal, so it won't double-update the input's value.