### PR TITLE
Textfield fill and ink styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- `mwc-textfield` ink and fill css variables
+
 ### Changed
 
 - **BREAKING** Removed `mwc-icon-font.js` import. Most users should load the

--- a/packages/notched-outline/README.md
+++ b/packages/notched-outline/README.md
@@ -21,4 +21,3 @@ outlined textfields and dropdown menus.
 | `--mdc-notched-outline-trailing-border-radius` | `0 4px 4px 0` | Radius of the border on the trailing end.
 | `--mdc-notched-outline-stroke-width`           | `1px`         | Outline width.
 | `--mdc-notched-outline-border-color`           | none          | Sets the border / outline color.
-| `--mdc-notched-outline-background-color`       | none          | Sets the background color inside the styled borders.

--- a/packages/notched-outline/README.md
+++ b/packages/notched-outline/README.md
@@ -20,3 +20,5 @@ outlined textfields and dropdown menus.
 | `--mdc-notched-outline-leading-border-radius`  | `4px 0 0 4px` | Radius of the border on the leading end. **May require setting `--mdc-notched-outline-leading-width` to accommodate for the new radius**
 | `--mdc-notched-outline-trailing-border-radius` | `0 4px 4px 0` | Radius of the border on the trailing end.
 | `--mdc-notched-outline-stroke-width`           | `1px`         | Outline width.
+| `--mdc-notched-outline-border-color`           | none          | Sets the border / outline color.
+| `--mdc-notched-outline-background-color`       | none          | Sets the background color inside the styled borders.

--- a/packages/notched-outline/src/mwc-notched-outline.scss
+++ b/packages/notched-outline/src/mwc-notched-outline.scss
@@ -78,7 +78,6 @@ limitations under the License.
 .mdc-notched-outline__notch,
 .mdc-notched-outline__trailing {
   border-color: var(--mdc-notched-outline-border-color, var(--mdc-theme-primary, #{$mdc-theme-primary}));
-  background-color: var(--mdc-notched-outline-background-color, #{$mdc-theme-primary});
 
   @include mdc-theme-prop(border-width, (
     varname: --mdc-notched-outline-stroke-width,

--- a/packages/notched-outline/src/mwc-notched-outline.scss
+++ b/packages/notched-outline/src/mwc-notched-outline.scss
@@ -78,6 +78,7 @@ limitations under the License.
 .mdc-notched-outline__notch,
 .mdc-notched-outline__trailing {
   border-color: var(--mdc-notched-outline-border-color, var(--mdc-theme-primary, #{$mdc-theme-primary}));
+  background-color: var(--mdc-notched-outline-background-color, #{$mdc-theme-primary});
 
   @include mdc-theme-prop(border-width, (
     varname: --mdc-notched-outline-stroke-width,

--- a/packages/textarea/src/mwc-textarea.scss
+++ b/packages/textarea/src/mwc-textarea.scss
@@ -27,10 +27,6 @@ limitations under the License.
   }
 
   &:not(.mdc-text-field--disabled) {
-    &:not(.mdc-text-field--fullwidth) {
-      @include mdc-text-field-fill-color($mdc-text-field-background);
-    }
-
     &:not(.mdc-text-field--invalid){
       @include mdc-theme-prop(border-bottom-color, $mdc-text-field-bottom-line-idle);
 

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -213,12 +213,8 @@ Inherits CSS Custom properties from:
 | `--mdc-text-field-outlined-idle-border-color`     | `rgba(0, 0, 0, 0.38)` | Color of the outlined textfield's  outline when idle.
 | `--mdc-text-field-outlined-hover-border-color`    | `rgba(0, 0, 0, 0.87)` | Color of the outlined textfield's outline when hovering.
 | `--mdc-text-field-outlined-disabled-border-color` | `rgba(0, 0, 0, 0.06)` | Color of the outlined textfield's outline when disabled.
-| `--mdc-text-field-fill-color`                     | filled: `rgb(245, 245, 245)`, outlined: `transparent` | Color of the textfield's background fill.
-| `--mdc-text-field-outlined-fill-color`            | `transparent`         | Overrides `--mdc-text-field-fill-color` only for outlined textfields.
-| `--mdc-text-field-filled-fill-color`              | `rgb(245,245,245)`    | Overrides `--mdc-text-field-fill-color` only for filled (non-outlined) textfields.
-| `--mdc-text-field-disabled-fill-color`            | filled: `rgb(250, 250, 250)`, outlined: `transparent` | Color of the textfield's background fill when disabled.
-| `--mdc-text-field-outlined-disabled-fill-color`   | `rgba(250, 250, 250)` | Overrides `--mdc-text-field-disabled-fill-color` only for outlined textfields.
-| `--mdc-text-field-filled-disabled-fill-color`     | `transparent`         | Overrides `--mdc-text-field-disabled-fill-color` only for filled (non-outlined) textfields.
+| `--mdc-text-field-fill-color`                     | `rgb(245, 245, 245)`  | Color of the textfield's background fill (non-outlined).
+| `--mdc-text-field-disabled-fill-color`            | `rgb(250, 250, 250)`  | Color of the textfield's background fill (non-outlined) when disabled.
 | `--mdc-text-field-ink-color`                      | `rgba(0, 0, 0, 0.87)` | Color of the input text.
 | `--mdc-text-field-label-ink-color`                | `rgba(0, 0, 0, 0.6)`  | Color of the non-focused floating label, helper text, char counter, and placeholder.
 | `--mdc-text-field-disabled-ink-color`             | `rgba(0, 0, 0, 0.37)` | Color of the input text, the floating label, helper text, char counter, and placeholder of a disabled textfield.

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -213,15 +213,15 @@ Inherits CSS Custom properties from:
 | `--mdc-text-field-outlined-idle-border-color`     | `rgba(0, 0, 0, 0.38)` | Color of the outlined textfield's  outline when idle.
 | `--mdc-text-field-outlined-hover-border-color`    | `rgba(0, 0, 0, 0.87)` | Color of the outlined textfield's outline when hovering.
 | `--mdc-text-field-outlined-disabled-border-color` | `rgba(0, 0, 0, 0.06)` | Color of the outlined textfield's outline when disabled.
-| `--mdc-text-field-fill-color` | filled: `rgb(245, 245, 245)`, outlined: `transparent` | Color of the textfield's background fill.
-| `--mdc-text-field-outlined-fill-color` | `transparent` | Overrides `--mdc-text-field-fill-color` only for outlined textfields.
-| `--mdc-text-field-filled-fill-color` | `rgb(245,245,245)` | Overrides `--mdc-text-field-fill-color` only for filled (non-outlined) textfields.
-| `--mdc-text-field-disabled-fill-color` | filled: `rgb(250, 250, 250)`, outlined: `transparent` | Color of the textfield's background fill when disabled.
-| `--mdc-text-field-outlined-disabled-fill-color` | `rgba(250, 250, 250)` | Overrides `--mdc-text-field-disabled-fill-color` only for outlined textfields.
-| `--mdc-text-field-filled-disabled-fill-color` | `transparent` | Overrides `--mdc-text-field-disabled-fill-color` only for filled (non-outlined) textfields.
-| `--mdc-text-field-ink-color` | `rgba(0, 0, 0, 0.87)` | Color of the input text.
-| `--mdc-text-field-label-ink-color` | `rgba(0, 0, 0, 0.6)` | Color of the non-focused floating label and placeholder.
-| `--mdc-text-field-disabled-ink-color` | `rgba(0, 0, 0, 0.37)` | Color of the input text, the floating label, and placeholder of a disabled textfield.
+| `--mdc-text-field-fill-color`                     | filled: `rgb(245, 245, 245)`, outlined: `transparent` | Color of the textfield's background fill.
+| `--mdc-text-field-outlined-fill-color`            | `transparent`         | Overrides `--mdc-text-field-fill-color` only for outlined textfields.
+| `--mdc-text-field-filled-fill-color`              | `rgb(245,245,245)`    | Overrides `--mdc-text-field-fill-color` only for filled (non-outlined) textfields.
+| `--mdc-text-field-disabled-fill-color`            | filled: `rgb(250, 250, 250)`, outlined: `transparent` | Color of the textfield's background fill when disabled.
+| `--mdc-text-field-outlined-disabled-fill-color`   | `rgba(250, 250, 250)` | Overrides `--mdc-text-field-disabled-fill-color` only for outlined textfields.
+| `--mdc-text-field-filled-disabled-fill-color`     | `transparent`         | Overrides `--mdc-text-field-disabled-fill-color` only for filled (non-outlined) textfields.
+| `--mdc-text-field-ink-color`                      | `rgba(0, 0, 0, 0.87)` | Color of the input text.
+| `--mdc-text-field-label-ink-color`                | `rgba(0, 0, 0, 0.6)`  | Color of the non-focused floating label, helper text, and placeholder.
+| `--mdc-text-field-disabled-ink-color`             | `rgba(0, 0, 0, 0.37)` | Color of the input text, the floating label, and placeholder of a disabled textfield.
 
 ### Validation
 

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -213,6 +213,15 @@ Inherits CSS Custom properties from:
 | `--mdc-text-field-outlined-idle-border-color`     | `rgba(0, 0, 0, 0.38)` | Color of the outlined textfield's  outline when idle.
 | `--mdc-text-field-outlined-hover-border-color`    | `rgba(0, 0, 0, 0.87)` | Color of the outlined textfield's outline when hovering.
 | `--mdc-text-field-outlined-disabled-border-color` | `rgba(0, 0, 0, 0.06)` | Color of the outlined textfield's outline when disabled.
+| `--mdc-text-field-fill-color` | filled: `rgb(245, 245, 245)`, outlined: `transparent` | Color of the textfield's background fill.
+| `--mdc-text-field-outlined-fill-color` | `transparent` | Overrides `--mdc-text-field-fill-color` only for outlined textfields.
+| `--mdc-text-field-filled-fill-color` | `rgb(245,245,245)` | Overrides `--mdc-text-field-fill-color` only for filled (non-outlined) textfields.
+| `--mdc-text-field-disabled-fill-color` | filled: `rgb(250, 250, 250)`, outlined: `transparent` | Color of the textfield's background fill when disabled.
+| `--mdc-text-field-outlined-disabled-fill-color` | `rgba(250, 250, 250)` | Overrides `--mdc-text-field-disabled-fill-color` only for outlined textfields.
+| `--mdc-text-field-filled-disabled-fill-color` | `transparent` | Overrides `--mdc-text-field-disabled-fill-color` only for filled (non-outlined) textfields.
+| `--mdc-text-field-ink-color` | `rgba(0, 0, 0, 0.87)` | Color of the input text.
+| `--mdc-text-field-label-ink-color` | `rgba(0, 0, 0, 0.6)` | Color of the non-focused floating label and placeholder.
+| `--mdc-text-field-disabled-ink-color` | `rgba(0, 0, 0, 0.37)` | Color of the input text, the floating label, and placeholder of a disabled textfield.
 
 ### Validation
 

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -220,8 +220,8 @@ Inherits CSS Custom properties from:
 | `--mdc-text-field-outlined-disabled-fill-color`   | `rgba(250, 250, 250)` | Overrides `--mdc-text-field-disabled-fill-color` only for outlined textfields.
 | `--mdc-text-field-filled-disabled-fill-color`     | `transparent`         | Overrides `--mdc-text-field-disabled-fill-color` only for filled (non-outlined) textfields.
 | `--mdc-text-field-ink-color`                      | `rgba(0, 0, 0, 0.87)` | Color of the input text.
-| `--mdc-text-field-label-ink-color`                | `rgba(0, 0, 0, 0.6)`  | Color of the non-focused floating label, helper text, and placeholder.
-| `--mdc-text-field-disabled-ink-color`             | `rgba(0, 0, 0, 0.37)` | Color of the input text, the floating label, and placeholder of a disabled textfield.
+| `--mdc-text-field-label-ink-color`                | `rgba(0, 0, 0, 0.6)`  | Color of the non-focused floating label, helper text, char counter, and placeholder.
+| `--mdc-text-field-disabled-ink-color`             | `rgba(0, 0, 0, 0.37)` | Color of the input text, the floating label, helper text, char counter, and placeholder of a disabled textfield.
 
 ### Validation
 

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -108,6 +108,10 @@ mwc-notched-outline {
     .mdc-text-field__input {
       color: var(--mdc-text-field-ink-color, #{$mdc-text-field-ink-color});
     }
+
+    .mdc-text-field__input::placeholder {
+      color: var(--mdc-text-field-label-ink-color, #{$mdc-text-field-label});
+    }
   }
 }
 
@@ -127,12 +131,12 @@ mwc-notched-outline {
 
     &:not(.mdc-text-field--invalid):not(.mdc-text-field--focused) {
       .mdc-floating-label, .mdc-floating-label::after {
-        color: var(--mdc-text-field-disabled-ink-color, $mdc-text-field-disabled-ink-color);
+        color: var(--mdc-text-field-disabled-ink-color, #{$mdc-text-field-disabled-ink-color});
       }
     }
 
-    .mdc-text-field__input {
-      color: var(--mdc-text-field-disabled-ink-color, $mdc-text-field-disabled-ink-color);
+    .mdc-text-field__input, .mdc-text-field__input::placeholder {
+      color: var(--mdc-text-field-disabled-ink-color, #{$mdc-text-field-disabled-ink-color});
     }
   }
 }

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -78,7 +78,6 @@ mwc-notched-outline {
       }
     }
 
-
     &:not(.mdc-text-field--invalid):not(.mdc-text-field--focused) {
       .mdc-floating-label, .mdc-floating-label::after {
         color: var(--mdc-text-field-label-ink-color, #{$mdc-text-field-label});
@@ -113,6 +112,13 @@ mwc-notched-outline {
       color: var(--mdc-text-field-label-ink-color, #{$mdc-text-field-label});
     }
   }
+
+  .mdc-text-field-helper-line {
+    .mdc-text-field-helper-text:not(.mdc-text-field-helper-text--validation-msg),
+    &:not(.mdc-text-field--invalid) .mdc-text-field-character-counter {
+      color: var(--mdc-text-field-label-ink-color, #{$mdc-text-field-label});
+    }
+  }
 }
 
 :host([disabled]) {
@@ -135,7 +141,15 @@ mwc-notched-outline {
       }
     }
 
-    .mdc-text-field__input, .mdc-text-field__input::placeholder {
+    .mdc-text-field__input,
+    .mdc-text-field__input::placeholder {
+      color: var(--mdc-text-field-disabled-ink-color, #{$mdc-text-field-disabled-ink-color});
+    }
+  }
+
+  .mdc-text-field-helper-line {
+    .mdc-text-field-helper-text,
+    .mdc-text-field-character-counter {
       color: var(--mdc-text-field-disabled-ink-color, #{$mdc-text-field-disabled-ink-color});
     }
   }

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -60,43 +60,79 @@ mwc-notched-outline {
   --mdc-notched-outline-border-color: var(--mdc-text-field-outlined-hover-border-color, #{$mdc-text-field-outlined-hover-border});
 }
 
-:host([disabled]) mwc-notched-outline {
-  --mdc-notched-outline-border-color: var(--mdc-text-field-outlined-disabled-border-color, #{$mdc-text-field-outlined-disabled-border});
+:host(:not([disabled])) {
+  .mdc-text-field {
+    &:not(.mdc-text-field--outlined) {
+      background-color: var(--mdc-text-field-filled-fill-color, var(--mdc-text-field-fill-color, #{$mdc-text-field-background}));
+    }
+
+    &.mdc-text-field--outlined {
+      --mdc-notched-outline-background-color: var(--mdc-text-field-outlined-fill-color, var(--mdc-text-field-fill-color, transparent));
+    }
+
+    &.mdc-text-field--invalid {
+      --mdc-notched-outline-border-color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));
+
+      &+.mdc-text-field-helper-line .mdc-text-field-character-counter, .mdc-text-field__icon {
+        color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));
+      }
+    }
+
+
+    &:not(.mdc-text-field--invalid):not(.mdc-text-field--focused) {
+      .mdc-floating-label, .mdc-floating-label::after {
+        color: var(--mdc-text-field-label-ink-color, #{$mdc-text-field-label});
+      }
+    }
+
+    &.mdc-text-field--focused {
+      mwc-notched-outline {
+        --mdc-notched-outline-stroke-width: 2px;
+      }
+
+      &:not(.mdc-text-field--invalid) {
+        mwc-notched-outline {
+          --mdc-notched-outline-border-color: var(--mdc-text-field-focused-label-color, var(--mdc-theme-primary, #{$mdc-text-field-focused-label-color}));
+        }
+
+        .mdc-floating-label {
+          @include mdc-theme-prop(color, primary);
+        }
+
+        @include mdc-required-text-field-label-asterisk_ {
+          @include mdc-theme-prop(color, primary);
+        }
+      }
+    }
+
+    .mdc-text-field__input {
+      color: var(--mdc-text-field-ink-color, #{$mdc-text-field-ink-color});
+    }
+  }
 }
 
-.mdc-text-field--invalid:not(.mdc-text-field--disabled) {
-  mwc-notched-outline {
-    --mdc-notched-outline-border-color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));
-  }
-
-  &+.mdc-text-field-helper-line .mdc-text-field-character-counter, .mdc-text-field__icon {
-    color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));
-  }
-}
-
-.mdc-text-field--focused:not(.mdc-text-field--disabled) {
-  mwc-notched-outline {
-    --mdc-notched-outline-stroke-width: 2px;
-  }
-
-  &:not(.mdc-text-field--invalid) {
-    mwc-notched-outline {
-      --mdc-notched-outline-border-color: var(--mdc-text-field-focused-label-color, var(--mdc-theme-primary, #{$mdc-text-field-focused-label-color}));
+:host([disabled]) {
+  .mdc-text-field {
+    &:not(.mdc-text-field--outlined) {
+      background-color: var(--mdc-text-field-filled-disabled-fill-color, var(--mdc-text-field-disabled-fill-color, #{$mdc-text-field-disabled-background}));
     }
 
-    .mdc-floating-label {
-      @include mdc-theme-prop(color, (
-        varname: --mdc-theme-primary,
-        fallback: $mdc-theme-primary
-      ));
+    &.mdc-text-field--outlined {
+      --mdc-notched-outline-background-color: var(--mdc-text-field-outlined-disabled-fill-color, var(--mdc-text-field-disabled-fill-color, transparent));
+
+      mwc-notched-outline {
+        --mdc-notched-outline-border-color: var(--mdc-text-field-outlined-disabled-border-color, #{$mdc-text-field-outlined-disabled-border});
+      }
     }
 
-    @include mdc-required-text-field-label-asterisk_ {
-      @include mdc-theme-prop(color, (
-        varname: --mdc-theme-primary,
-        fallback: $mdc-theme-primary
-      ));
+    &:not(.mdc-text-field--invalid):not(.mdc-text-field--focused) {
+      .mdc-floating-label, .mdc-floating-label::after {
+        color: var(--mdc-text-field-disabled-ink-color, $mdc-text-field-disabled-ink-color);
+      }
+    }
+
+    .mdc-text-field__input {
+      color: var(--mdc-text-field-disabled-ink-color, $mdc-text-field-disabled-ink-color);
     }
   }
-
 }

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -66,7 +66,7 @@ mwc-notched-outline {
       background-color: var(--mdc-text-field-fill-color, #{$mdc-text-field-background});
     }
 
-    &.mdc-text-field--invalid {
+    &.mdc-text-field--invalid mwc-notched-outline {
       --mdc-notched-outline-border-color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));
 
       &+.mdc-text-field-helper-line .mdc-text-field-character-counter, .mdc-text-field__icon {

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -63,11 +63,7 @@ mwc-notched-outline {
 :host(:not([disabled])) {
   .mdc-text-field {
     &:not(.mdc-text-field--outlined) {
-      background-color: var(--mdc-text-field-filled-fill-color, var(--mdc-text-field-fill-color, #{$mdc-text-field-background}));
-    }
-
-    &.mdc-text-field--outlined {
-      --mdc-notched-outline-background-color: var(--mdc-text-field-outlined-fill-color, var(--mdc-text-field-fill-color, transparent));
+      background-color: var(--mdc-text-field-fill-color, #{$mdc-text-field-background});
     }
 
     &.mdc-text-field--invalid {
@@ -124,12 +120,10 @@ mwc-notched-outline {
 :host([disabled]) {
   .mdc-text-field {
     &:not(.mdc-text-field--outlined) {
-      background-color: var(--mdc-text-field-filled-disabled-fill-color, var(--mdc-text-field-disabled-fill-color, #{$mdc-text-field-disabled-background}));
+      background-color: var(--mdc-text-field-disabled-fill-color, #{$mdc-text-field-disabled-background});
     }
 
     &.mdc-text-field--outlined {
-      --mdc-notched-outline-background-color: var(--mdc-text-field-outlined-disabled-fill-color, var(--mdc-text-field-disabled-fill-color, transparent));
-
       mwc-notched-outline {
         --mdc-notched-outline-border-color: var(--mdc-text-field-outlined-disabled-border-color, #{$mdc-text-field-outlined-disabled-border});
       }

--- a/packages/textfield/src/mwc-textfield.scss
+++ b/packages/textfield/src/mwc-textfield.scss
@@ -66,8 +66,10 @@ mwc-notched-outline {
       background-color: var(--mdc-text-field-fill-color, #{$mdc-text-field-background});
     }
 
-    &.mdc-text-field--invalid mwc-notched-outline {
-      --mdc-notched-outline-border-color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));
+    &.mdc-text-field--invalid {
+      mwc-notched-outline {
+        --mdc-notched-outline-border-color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));
+      }
 
       &+.mdc-text-field-helper-line .mdc-text-field-character-counter, .mdc-text-field__icon {
         color: var(--mdc-text-field-error-color, var(--mdc-theme-error, #{$mdc-theme-error}));


### PR DESCRIPTION
Fixes #460.
Fixes #544.

Refactored textfield styling to make more conceptual sense and collapse common selectors. Additionally, added the following css variables:

## mwc-textfield

| Name                                              | Default               | Description
| ------------------------------------------------- | --------------------- |------------
| `--mdc-text-field-fill-color`                     | filled: `rgb(245, 245, 245)`, outlined: `transparent` | Color of the textfield's background fill.
| `--mdc-text-field-disabled-fill-color`            | filled: `rgb(250, 250, 250)`, outlined: `transparent` | Color of the textfield's background fill when disabled.
| `--mdc-text-field-ink-color`                      | `rgba(0, 0, 0, 0.87)` | Color of the input text.
| `--mdc-text-field-label-ink-color`                | `rgba(0, 0, 0, 0.6)`  | Color of the non-focused floating label, helper text, char counter, and placeholder.
| `--mdc-text-field-disabled-ink-color`             | `rgba(0, 0, 0, 0.37)` | Color of the input text, the floating label, helper text, char counter, and placeholder of a disabled textfield.

## mwc-notched-outline
| Name                                           | Default       | Description
| ---------------------------------------------- | ------------- |------------
| `--mdc-notched-outline-border-color`           | none          | Sets the border / outline color. **(NOTE only added missing documentation for this one)**
| `--mdc-notched-outline-background-color`       | none          | Sets the background color inside the styled borders.