### PR TITLE
fixed error is validityTransform documentation

### DIFF
--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -147,7 +147,7 @@ npm install @material/mwc-textarea
 | `validationMessage` | `string`         | Message to show in the error color when the textarea is invalid. (Helper text will not be visible)
 | `validity`          | `ValidityState` (readonly) | The [`ValidityState`](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) of the textfield.
 | `willValidate`      | `boolean` (readonly)       | [`HTMLInputElement.prototype.willValidate`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties)
-| `validityTransform` | `ValidityTransform**\|null` | Callback called before each validation check. See the [validation section](#Validation) for more details.
+| `validityTransform` | `ValidityTransform**`\|`null` | Callback called before each validation check. See the [validation section](#Validation) for more details.
 | `validateOnInitialRender` | `boolean`            | Runs validation check on initial render.
 
 \*  `TextFieldType` is exported by `mwc-textarea` and `mwc-textarea-base`.

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -147,7 +147,7 @@ npm install @material/mwc-textarea
 | `validationMessage` | `string`         | Message to show in the error color when the textarea is invalid. (Helper text will not be visible)
 | `validity`          | `ValidityState` (readonly) | The [`ValidityState`](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) of the textfield.
 | `willValidate`      | `boolean` (readonly)       | [`HTMLInputElement.prototype.willValidate`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties)
-| `validityTransform` | `ValidityTransform**|null` | Callback called before each validation check. See the [validation section](#Validation) for more details.
+| `validityTransform` | `ValidityTransform**\|null` | Callback called before each validation check. See the [validation section](#Validation) for more details.
 | `validateOnInitialRender` | `boolean`            | Runs validation check on initial render.
 
 \*  `TextFieldType` is exported by `mwc-textarea` and `mwc-textarea-base`.


### PR DESCRIPTION
prefix of \ to render | properly in docs for validityTransform (otherwise interpreted as table column)