### PR TITLE
fix ripple shadow root

### DIFF
--- a/packages/ripple/src/mwc-ripple-base.ts
+++ b/packages/ripple/src/mwc-ripple-base.ts
@@ -34,9 +34,12 @@ export class RippleBase extends LitElement {
 
   connectedCallback() {
     if (this.interactionNode === this) {
-      const parent = this.parentNode as HTMLElement;
+      const parent = this.parentNode as HTMLElement | ShadowRoot | null;
       if (parent instanceof HTMLElement) {
         this.interactionNode = parent;
+      } else if (
+          parent instanceof ShadowRoot && parent.host instanceof HTMLElement) {
+        this.interactionNode = parent.host;
       }
     }
     super.connectedCallback();

--- a/packages/ripple/src/test/mwc-ripple.test.ts
+++ b/packages/ripple/src/test/mwc-ripple.test.ts
@@ -84,6 +84,6 @@ suite('mwc-ripple', () => {
       assert(internals.interactionNode === container);
 
       document.body.removeChild(container);
-    })
+    });
   });
 });

--- a/packages/ripple/src/test/mwc-ripple.test.ts
+++ b/packages/ripple/src/test/mwc-ripple.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {Ripple} from '@material/mwc-ripple';
+import assert = require('http-assert');
 
 interface RippleInternals {
   interactionNode: HTMLElement;
@@ -50,7 +51,7 @@ suite('mwc-ripple', () => {
     });
   });
 
-  suite('nested', () => {
+  suite('interactionNode', () => {
     test('respects interactionNode', async () => {
       container = document.createElement('div');
       document.body.appendChild(container);
@@ -67,5 +68,21 @@ suite('mwc-ripple', () => {
 
       document.body.removeChild(container);
     });
+
+    test('ripple whose parent is shadowRoot selects host', async () => {
+      container = document.createElement('div');
+      const root = container.attachShadow({mode: 'open'});
+      document.body.appendChild(container);
+
+      const ripple = document.createElement('mwc-ripple');
+      const internals = ripple as unknown as RippleInternals;
+
+      root.appendChild(ripple);
+
+      assert(internals.interactionNode instanceof HTMLElement);
+      assert(internals.interactionNode === container);
+
+      document.body.removeChild(container);
+    })
   });
 });

--- a/packages/ripple/src/test/mwc-ripple.test.ts
+++ b/packages/ripple/src/test/mwc-ripple.test.ts
@@ -16,7 +16,6 @@
  */
 
 import {Ripple} from '@material/mwc-ripple';
-import assert = require('http-assert');
 
 interface RippleInternals {
   interactionNode: HTMLElement;
@@ -79,7 +78,9 @@ suite('mwc-ripple', () => {
 
       root.appendChild(ripple);
 
-      assert(internals.interactionNode instanceof HTMLElement);
+      await ripple.updateComplete;
+
+      assert.instanceOf(internals.interactionNode, HTMLElement);
       assert(internals.interactionNode === container);
 
       document.body.removeChild(container);


### PR DESCRIPTION
ripple won't be able to register clicks if the direct parent is a shadow root. This fixes this.