### PR TITLE
Slider scroll fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 !packages/*/custom_types/**
 /test/lib/
 /scripts/tsc-out/
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - CSS styling options to `mwc-textfield`
 - README for `mwc-drawer`
 - Demo for `mwc-drawer` without a header in the drawer
+- `--mdc-icon-button-size` and `--mdc-icon-size` to `mwc-icon-button`
 
 ### Changed
 
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue where slider when resized or scrolled will not respond to touch
   as expected.
 - Fixed issue where `mwc-ripple` would not ripple when parent was a shadow root
+- **BREAKING:VISUAL** Fixed sizing of the `mwc-icon-button` in `mwc-snackbar`
 
 ## [0.10.0] - 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `mwc-dialog` will now search its flattened distributed nodes and their trees
   for a focusable element.
 - **BREAKING** `mwc-slider` now emits bubbling and composed `input` and `change`
-  events from `MDCSlider:input` and `MDCSlider:change`.
+  events instead of `MDCSlider:input` and `MDCSlider:change`.
 
 ### Fixed
 - Fixed checkbox ripple visibility when focused while being unchecked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated material dependencies to `4.0.0-canary.735147131.0`.
 - `mwc-dialog` will now search its flattened distributed nodes and their trees
   for a focusable element.
+- **BREAKING** `mwc-slider` now emits bubbling and composed `input` and `change`
+  events from `MDCSlider:input` and `MDCSlider:change`.
 
 ### Fixed
 - Fixed checkbox ripple visibility when focused while being unchecked.
 - Fixed app content not being expanded inside drawer.
+- Fixed issue where slider when resized or scrolled will not respond to touch
+  as expected.
 
 ## [0.10.0] - 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed app content not being expanded inside drawer.
 - Fixed issue where slider when resized or scrolled will not respond to touch
   as expected.
+- Fixed issue where `mwc-ripple` would not ripple when parent was a shadow root
 
 ## [0.10.0] - 2019-10-11
 

--- a/packages/slider/src/mwc-slider-base.ts
+++ b/packages/slider/src/mwc-slider-base.ts
@@ -116,7 +116,7 @@ export class SliderBase extends FormElement {
            aria-valuenow="${this.value}" aria-disabled="${this.disabled}"
            data-step="${this.step}"
            @mousedown=${this.layout}
-           @touchmove=${this.layout}>
+           @touchstart=${this.layout}>
         <div class="mdc-slider__track-container">
           <div
               class="mdc-slider__track"
@@ -158,7 +158,19 @@ export class SliderBase extends FormElement {
       setAttribute: (name: string, value: string) =>
           this.mdcRoot.setAttribute(name, value),
       removeAttribute: (name: string) => this.mdcRoot.removeAttribute(name),
-      computeBoundingRect: () => this.mdcRoot.getBoundingClientRect(),
+      computeBoundingRect: () => {
+        const rect = this.mdcRoot.getBoundingClientRect();
+        const myRect: ClientRect = {
+          bottom: rect.bottom,
+          height: rect.height,
+          left: rect.left + window.pageXOffset,
+          right: rect.right,
+          top: rect.top,
+          width: rect.width,
+        };
+
+        return myRect;
+      },
       getTabIndex: () => this.mdcRoot.tabIndex,
       registerInteractionHandler:
           <K extends EventType>(type: K, handler: SpecificEventListener<K>) => {

--- a/packages/slider/src/mwc-slider-base.ts
+++ b/packages/slider/src/mwc-slider-base.ts
@@ -243,6 +243,14 @@ export class SliderBase extends FormElement {
     };
   }
 
+  /**
+   * Layout is called on mousedown / touchstart as the dragging animations of
+   * slider are calculated based off of the bounding rect which can change
+   * between interactions with this component, and this is the only location
+   * in the foundation that udpates the rects. e.g. scrolling horizontally
+   * causes adverse effects on the bounding rect vs mouse drag / touchmove
+   * location.
+   */
   @eventOptions({capture: true, passive: true})
   layout() {
     this.mdcFoundation.layout();

--- a/packages/slider/src/mwc-slider-base.ts
+++ b/packages/slider/src/mwc-slider-base.ts
@@ -18,11 +18,12 @@ import {applyPassive} from '@material/dom/events.js';
 import {addHasRemoveClass, EventType, FormElement, observer, SpecificEventListener} from '@material/mwc-base/form-element.js';
 import {MDCSliderAdapter} from '@material/slider/adapter.js';
 import MDCSliderFoundation from '@material/slider/foundation.js';
-import {html, property, query, TemplateResult} from 'lit-element';
+import {eventOptions, html, property, query, TemplateResult} from 'lit-element';
 import {classMap} from 'lit-html/directives/class-map';
 import {styleMap} from 'lit-html/directives/style-map';
 
-const {INPUT_EVENT, CHANGE_EVENT} = MDCSliderFoundation.strings;
+const INPUT_EVENT = 'input';
+const CHANGE_EVENT = 'change';
 
 export class SliderBase extends FormElement {
   protected mdcFoundation!: MDCSliderFoundation;
@@ -113,22 +114,24 @@ export class SliderBase extends FormElement {
            tabindex="0" role="slider"
            aria-valuemin="${this.min}" aria-valuemax="${this.max}"
            aria-valuenow="${this.value}" aria-disabled="${this.disabled}"
-           data-step="${this.step}">
-      <div class="mdc-slider__track-container">
-        <div
-            class="mdc-slider__track"
-            style="${styleMap(this.trackStyles)}">
+           data-step="${this.step}"
+           @mousedown=${this.layout}
+           @touchmove=${this.layout}>
+        <div class="mdc-slider__track-container">
+          <div
+              class="mdc-slider__track"
+              style="${styleMap(this.trackStyles)}">
+          </div>
+          ${markersTemplate}
         </div>
-        ${markersTemplate}
-      </div>
-      <div
-          class="mdc-slider__thumb-container"
-          style="${styleMap(this.thumbContainerStyles)}">
-        <!-- TODO: use cache() directive -->
-        ${pin}
-        <svg class="mdc-slider__thumb" width="21" height="21">
-          <circle cx="10.5" cy="10.5" r="7.875"></circle>
-        </svg>
+        <div
+            class="mdc-slider__thumb-container"
+            style="${styleMap(this.thumbContainerStyles)}">
+          <!-- TODO: use cache() directive -->
+          ${pin}
+          <svg class="mdc-slider__thumb" width="21" height="21">
+            <circle cx="10.5" cy="10.5" r="7.875"></circle>
+          </svg>
         <div class="mdc-slider__focus-ring"></div>
       </div>
     </div>`;
@@ -188,12 +191,14 @@ export class SliderBase extends FormElement {
         if (value !== this.value) {
           this.value = value;
           this.dispatchEvent(new CustomEvent(
-              INPUT_EVENT, {detail: this, bubbles: true, cancelable: true}));
+              INPUT_EVENT,
+              {detail: this, composed: true, bubbles: true, cancelable: true}));
         }
       },
       notifyChange: () => {
         this.dispatchEvent(new CustomEvent(
-            CHANGE_EVENT, {detail: this, bubbles: true, cancelable: true}));
+            CHANGE_EVENT,
+            {detail: this, composed: true, bubbles: true, cancelable: true}));
       },
       setThumbContainerStyleProperty: (propertyName: string, value: string) => {
         this.thumbContainerStyles[propertyName] = value;
@@ -226,6 +231,7 @@ export class SliderBase extends FormElement {
     };
   }
 
+  @eventOptions({capture: true, passive: true})
   layout() {
     this.mdcFoundation.layout();
   }


### PR DESCRIPTION
Fixed issue where slider when scrolled horizontally or when resized would not slide properly by calling layout (which gets bounding client rect) on touchstart or mousedown.

Also changelog for this and my other icon-button, ripple and snackbar PRs

Fixes #574