### PR TITLE
search flattened distributed for focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `--mdc-dialog-title-ink-color` renamed to `--mdc-dialog-heading-ink-color` as
   it caused clashes with `HTMLElement.prototype.title`.
 - Updated material dependencies to `4.0.0-canary.735147131.0`.
+- `mwc-dialog` will now search its flattened distributed nodes and their trees
+  for a focusable element.
 
 ### Fixed
 - Fixed checkbox ripple visibility when focused while being unchecked.

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -353,9 +353,9 @@ For example:
 
 In this example we set `dialogInitialFocus` on the `mwc-textfield`, so
 `mwc-textfield.focus()` will be called on the button. This attribute can also be
-set on anything in the light DOM of `mwc-dialog` including the primary and
-secondary actions. Only one element designated with this attribute will be
-focused.
+set on anything in the light DOM of `mwc-dialog` or the light dom of the
+flattened, distributed nodes including the primary and secondary actions. Only
+one element designated with this attribute will be focused.
 
 Calling `focus()` on the `mwc-dialog` itself will call `focus()` on any
 `dialogInitialFocus` element in the light DOM of `mwc-dialog`.

--- a/packages/dialog/src/mwc-dialog-base.ts
+++ b/packages/dialog/src/mwc-dialog-base.ts
@@ -130,28 +130,30 @@ export class DialogBase extends BaseElement {
     }
 
     // if not in light dom, search each flattened distributed node.
-    const content = this.contentSlot as HTMLSlotElement;
     const primary = this.primarySlot as HTMLSlotElement;
     const secondary = this.secondarySlot as HTMLSlotElement;
+    const content = this.contentSlot as HTMLSlotElement;
 
-    const contentNodes = content.assignedNodes({flatten: true});
+
     const primaryNodes = primary.assignedNodes({flatten: true});
-    const secondaryNodes = secondary.assignedNodes({flatten: true});
-
-    const initFocusElement = this.searchNodeTreesForAttribute(
-        contentNodes, this.initialFocusAttribute);
-    if (initFocusElement) {
-      return initFocusElement;
-    }
-
     const primaryFocusElement = this.searchNodeTreesForAttribute(
         primaryNodes, this.initialFocusAttribute);
     if (primaryFocusElement) {
       return primaryFocusElement;
     }
+
+    const secondaryNodes = secondary.assignedNodes({flatten: true});
     const secondaryFocusElement = this.searchNodeTreesForAttribute(
         secondaryNodes, this.initialFocusAttribute);
-    return secondaryFocusElement;
+    if (secondaryFocusElement) {
+      return secondaryFocusElement;
+    }
+
+
+    const contentNodes = content.assignedNodes({flatten: true});
+    const initFocusElement = this.searchNodeTreesForAttribute(
+        contentNodes, this.initialFocusAttribute);
+    return initFocusElement;
   }
 
   private searchNodeTreesForAttribute(nodes: Node[], attribute: string):

--- a/packages/dialog/src/mwc-dialog-base.ts
+++ b/packages/dialog/src/mwc-dialog-base.ts
@@ -130,19 +130,16 @@ export class DialogBase extends BaseElement {
     }
 
     // if not in light dom, search each flattened distributed node.
-    const primary = this.primarySlot as HTMLSlotElement;
-    const secondary = this.secondarySlot as HTMLSlotElement;
-    const content = this.contentSlot as HTMLSlotElement;
-
-
-    const primaryNodes = primary.assignedNodes({flatten: true});
+    const primarySlot = this.primarySlot as HTMLSlotElement;
+    const primaryNodes = primarySlot.assignedNodes({flatten: true});
     const primaryFocusElement = this.searchNodeTreesForAttribute(
         primaryNodes, this.initialFocusAttribute);
     if (primaryFocusElement) {
       return primaryFocusElement;
     }
 
-    const secondaryNodes = secondary.assignedNodes({flatten: true});
+    const secondarySlot = this.secondarySlot as HTMLSlotElement;
+    const secondaryNodes = secondarySlot.assignedNodes({flatten: true});
     const secondaryFocusElement = this.searchNodeTreesForAttribute(
         secondaryNodes, this.initialFocusAttribute);
     if (secondaryFocusElement) {
@@ -150,7 +147,8 @@ export class DialogBase extends BaseElement {
     }
 
 
-    const contentNodes = content.assignedNodes({flatten: true});
+    const contentSlot = this.contentSlot as HTMLSlotElement;
+    const contentNodes = contentSlot.assignedNodes({flatten: true});
     const initFocusElement = this.searchNodeTreesForAttribute(
         contentNodes, this.initialFocusAttribute);
     return initFocusElement;

--- a/packages/dialog/src/mwc-dialog-base.ts
+++ b/packages/dialog/src/mwc-dialog-base.ts
@@ -167,8 +167,8 @@ export class DialogBase extends BaseElement {
         return node;
       } else {
         const selection = node.querySelector(`[${attribute}]`);
-        if (selection instanceof HTMLElement) {
-          return selection;
+        if (selection) {
+          return selection as HTMLElement;
         }
       }
     }

--- a/packages/dialog/src/mwc-dialog-base.ts
+++ b/packages/dialog/src/mwc-dialog-base.ts
@@ -47,7 +47,7 @@ export class DialogBase extends BaseElement {
   // undefined" error in browsers that don't define it (e.g. Edge and IE11).
   @query('slot[name="secondaryAction"]') protected secondarySlot!: HTMLElement;
 
-  @query('#content slot') protected contentSlot!: HTMLElement;
+  @query('#contentSlot') protected contentSlot!: HTMLElement;
 
   @query('.mdc-dialog__content') protected contentElement!: HTMLDivElement;
 
@@ -254,7 +254,7 @@ export class DialogBase extends BaseElement {
         <div class="mdc-dialog__surface">
           ${heading}
           <div id="content" class="mdc-dialog__content">
-            <slot></slot>
+            <slot id="contentSlot"></slot>
           </div>
           <footer
               id="actions"


### PR DESCRIPTION
Dialog will now search its distributed nodes' trees for focus. Needed for the following pattern:

```html
<my-dialog>
  <input dialogInitialFocus>
  #shadowRoot
    <mwc-dialog>
      <slot></slot>
    </mwc-dialog>
</my-dialog>
```