### PR TITLE
Dialog show and close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - CSS styling options to `mwc-tab`
 - `active` attribute to `mwc-tab` when (de)activated
 - Added  custom properties to style `mwc-checkbox`'s colors
+- Added `show` and `close` methods to `mwc-dialog`
 
 ### Fixed
 

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -232,7 +232,10 @@ npm install @material/mwc-dialog
 | -------- | -------------
 | `forceLayout() => void` | Forces dialog to relayout (animation frame time). May be required if dialog size is incorrect or if stacked layout has not been triggered correctly.
 | `focus() => void` | Focuses on the initial focus element if defined (see [focus section](#focus)).
-| `blur() => void` | Blurs the active element.
+| `blur() => void`  | Blurs the active element.
+| `blur() => void`  | Blurs the active element.
+| `show() => void`  | Opens the dialog.
+| `close() => void` | Closes the dialog.
 
 ### Listeners
 | Event Name          | Target       | Description

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -233,7 +233,6 @@ npm install @material/mwc-dialog
 | `forceLayout() => void` | Forces dialog to relayout (animation frame time). May be required if dialog size is incorrect or if stacked layout has not been triggered correctly.
 | `focus() => void` | Focuses on the initial focus element if defined (see [focus section](#focus)).
 | `blur() => void`  | Blurs the active element.
-| `blur() => void`  | Blurs the active element.
 | `show() => void`  | Opens the dialog.
 | `close() => void` | Closes the dialog.
 

--- a/packages/dialog/src/mwc-dialog-base.ts
+++ b/packages/dialog/src/mwc-dialog-base.ts
@@ -388,4 +388,12 @@ export class DialogBase extends BaseElement {
           'keydown', this.boundHandleDocumentKeydown);
     }
   }
+
+  close() {
+    this.open = false;
+  }
+
+  show() {
+    this.open = true;
+  }
 }


### PR DESCRIPTION
Added `show` and `close` methods to dialog because it is closer to `HTMLDialogElement` and because relying only on property runs into the following issue:

```ts
class MyElement extends LitElement {
  @property() isDialogOpen = true;

  render() {
    return html`
      <mwc-dialog .open=${this.isDialogOpen}></mwc-dialog>
    `;
  }
}
```

When user closes dialog with interaction, `isDialogOpen` will remain true while `mwc-dialog` remains false. If they want to open it again, they must call `this.requestUpdate('isDialogOpen')`.