### PR TITLE
Allow bump MDC deps action to trigger tests

### DIFF
--- a/.github/workflows/bump-mdc-deps.yml
+++ b/.github/workflows/bump-mdc-deps.yml
@@ -33,7 +33,7 @@ jobs:
       # https://github.com/github/hub instead?
       uses: peter-evans/create-pull-request@v1.5.2
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.TEDIUM_BOT_GITHUB_ACCESS_TOKEN }}
         COMMIT_MESSAGE: Auto bump MDC Web deps to ${{ steps.bump.outputs.new-mdc-version }}
         # TODO Find or make an account that is whitelisted to not trigger the# CLA check.
         COMMIT_AUTHOR_EMAIL: format-bot@polymer-project.org


### PR DESCRIPTION
I signed into the tedium-bot (Polymer automation account) GitHub page, created a personal access token, and added it to this repo's secrets as `TEDIUM_BOT_GITHUB_ACCESS_TOKEN`.

By using this token instead of the automatically populated `GITHUB_TOKEN` token, subsequent GitHub Actions will be allowed to run on the PR we create (i.e. tests).

See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092 for an explanation of this workaround.