### PR TITLE
feat: list-item.selected will update list model

### DIFF
--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -465,8 +465,8 @@ of `mwc-list-item`, so all properties in `mwc-list-item` will be available on
 
 | Event Name | Target       | Detail             | Description
 | ---------- | ------------ | ------------------ | -----------
-| `action`  | `mwc-list`    | `ActionDetail`*    | Fired when a selection has been made via click or keyboard aciton.
-| `selected`  | `mwc-list` | `SelectedDetail`**   | Fired when a selection has been made. `index` is the selected index (will be of type `Set<number>` if multi and `number` if single), and `diff` (of type `IndexDiff`**) represents the diff of added and removed indices from previous selection.
+| `action`   | `mwc-list`   | `ActionDetail`*    | Fired when a selection has been made via click or keyboard aciton.
+| `selected` | `mwc-list`   | `SelectedDetail`** | Fired when a selection has been made. `index` is the selected index (will be of type `Set<number>` if multi and `number` if single), and `diff` (of type `IndexDiff`**) represents the diff of added and removed indices from previous selection.
 
 \* `ActionDetail` is an interface of the following type:
 
@@ -525,14 +525,14 @@ mwcList.addEventListener('selected', onSelected);
 
 | Event Name          | Target          | Detail                   | Description
 | ------------------- | --------------- | ------------------------ | -----------
-| `request-selected`  | `mwc-list-item` | `RequestSelectedDetail`* | Fired upon click. Requests selection from the `mwc-list`.
+| `request-selected`  | `mwc-list-item` | `RequestSelectedDetail`* | Fired upon click and when `selected` property is changed. Requests selection from the `mwc-list`.
 
 \* `RequestSelectedDetail` is an interface of the following type:
 
 ```ts
 interface RequestSelectedDetail {
   selected: boolean;
-  isClick: boolean;
+  source: 'interaction'|'property';
 }
 ```
 

--- a/packages/list/src/mwc-check-list-item-base.ts
+++ b/packages/list/src/mwc-check-list-item-base.ts
@@ -57,7 +57,7 @@ export class CheckListItemBase extends ListItemBase {
   }
 
   protected onClick() {
-    this.fireRequestDetail(true, !this.selected);
+    this.fireRequestDetail(!this.selected, 'interaction');
   }
 
   connectedCallback() {

--- a/packages/list/src/mwc-list-base.ts
+++ b/packages/list/src/mwc-list-base.ts
@@ -248,8 +248,10 @@ export abstract class ListBase extends BaseElement {
       }
 
       const selected = evt.detail.selected;
+      const source = evt.detail.source;
 
-      this.mdcFoundation.handleSingleSelection(index, selected);
+      this.mdcFoundation.handleSingleSelection(
+          index, source === 'interaction', selected);
 
       evt.stopPropagation();
     }
@@ -435,7 +437,9 @@ export abstract class ListBase extends BaseElement {
   }
 
   toggle(index: number, force?: boolean) {
-    this.mdcFoundation.toggleMultiAtIndex(index, force);
+    if (this.multi) {
+      this.mdcFoundation.toggleMultiAtIndex(index, force);
+    }
   }
 
   protected onSlotChange() {

--- a/packages/list/src/mwc-list-item-base.ts
+++ b/packages/list/src/mwc-list-item-base.ts
@@ -19,9 +19,10 @@ import {observer} from '@material/mwc-base/observer';
 import {rippleNode} from '@material/mwc-ripple/ripple-directive';
 import {html, LitElement, property, query} from 'lit-element';
 
+export type SelectionSource = 'interaction'|'property';
 export interface RequestSelectedDetail {
   selected: boolean;
-  isClick: boolean;
+  source: SelectionSource;
 }
 
 export type GraphicType = 'avatar'|'icon'|'medium'|'large'|'control'|null;
@@ -68,10 +69,17 @@ export class ListItemBase extends LitElement {
     } else {
       this.setAttribute('aria-selected', 'false');
     }
+
+    if (this._firstChanged) {
+      this._firstChanged = false;
+    } else {
+      this.fireRequestDetail(value, 'property');
+    }
   })
   selected = false;
 
   protected boundOnClick = this.onClick.bind(this);
+  protected _firstChanged = true;
 
   get text() {
     const textContent = this.textContent;
@@ -128,13 +136,13 @@ export class ListItemBase extends LitElement {
   }
 
   protected onClick() {
-    this.fireRequestDetail(false, !this.selected);
+    this.fireRequestDetail(!this.selected, 'interaction');
   }
 
-  protected fireRequestDetail(isClick: boolean, selected: boolean) {
+  protected fireRequestDetail(selected: boolean, source: SelectionSource) {
     const customEv = new CustomEvent<RequestSelectedDetail>(
         'request-selected',
-        {bubbles: true, composed: true, detail: {isClick, selected}});
+        {bubbles: true, composed: true, detail: {source, selected}});
 
     this.dispatchEvent(customEv);
   }

--- a/packages/list/src/mwc-radio-list-item-base.ts
+++ b/packages/list/src/mwc-radio-list-item-base.ts
@@ -30,7 +30,6 @@ export class RadioListItemBase extends ListItemBase {
 
   @property({type: Boolean}) left = false;
   @property({type: String, reflect: true}) graphic: GraphicType = 'control';
-  @property({type: Boolean, reflect: false})
 
   render() {
     const radioClasses = {
@@ -62,7 +61,7 @@ export class RadioListItemBase extends ListItemBase {
 
 
   protected onClick() {
-    this.fireRequestDetail(true, !this.selected);
+    this.fireRequestDetail(!this.selected, 'interaction');
   }
 
   protected onChecked(evt: Event) {
@@ -72,7 +71,7 @@ export class RadioListItemBase extends ListItemBase {
       // needed to reconcile radio unchecking itself. List doesn't seem to care
       this.selected = radio.checked;
 
-      this.fireRequestDetail(false, this.selected);
+      this.fireRequestDetail(this.selected, 'interaction');
     }
   }
 

--- a/packages/menu/src/mwc-menu-base.ts
+++ b/packages/menu/src/mwc-menu-base.ts
@@ -145,18 +145,18 @@ export abstract class MenuBase extends BaseElement {
           @closed=${this.onClosed}
           @opened=${this.onOpened}
           @keydown=${this.onKeydown}>
-          <mwc-list
-            rootTabbable
-            .innerRole=${this.innerRole}
-            .multi=${this.multi}
-            class="mdc-list"
-            .itemRoles=${itemRoles}
-            .wrapFocus=${this.wrapFocus}
-            .activatable=${this.activatable}
-            @action=${this.onAction}>
-          <slot></slot>
-        </mwc-list>
-      </mwc-menu-surface>`;
+        <mwc-list
+          rootTabbable
+          .innerRole=${this.innerRole}
+          .multi=${this.multi}
+          class="mdc-list"
+          .itemRoles=${itemRoles}
+          .wrapFocus=${this.wrapFocus}
+          .activatable=${this.activatable}
+          @action=${this.onAction}>
+        <slot></slot>
+      </mwc-list>
+    </mwc-menu-surface>`;
   }
 
   protected createAdapter(): MDCMenuAdapter {


### PR DESCRIPTION
Fixes #876 

Before:

you had to call `layout` every time you manually modified the DOM and set `<mwc-list-item selected>` outside of the initial render. The supported way before was to call `mwc-list.select(index)`.

caused issues where initial selection was made due to asynchronous calls. Also was not nice to deal with data-binding, especially with `mwc-select`

Now:

you can set `select` on an `mwc-list-item` and it updates `mwc-list` accordingly.