### PR TITLE
Fix Sass "default" imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Setting `scrollTarget` on `mwc-top-app-bar` will update listeners
+- Fixed sass imports of `_index.scss` files
 
 ## [0.13.0] - 2019-02-03
 

--- a/scripts/sass-render/index.js
+++ b/scripts/sass-render/index.js
@@ -29,7 +29,12 @@ const delim = /<%\s*content\s*%>/;
 async function sassToCss(sassFile) {
   const result = await renderSass({
     file: sassFile,
-    importer: nodeSassImport,
+    importer: (url, ...otherArgs) => {
+      if (url.split('/').length === 2) {
+        url += '/_index.scss';
+      }
+      return nodeSassImport(url, ...otherArgs);
+    },
     outputStyle: 'compressed',
   });
   return result.css.toString();


### PR DESCRIPTION
- Sass now has "default" imports that should handle `@material/theme` to
  mean `@material/theme/_index.scss` that `node-sass-import` did not
  understand

  Fixes #850