### PR TITLE
chore: move lint and format checks earlier in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,14 @@ jobs:
     - name: Lerna bootstrap
       run: npm run bootstrap
 
+    # TODO(aomarks) Once b/144957560 is fixed, move lint and format into their
+    # own workflows or jobs so that they can run in parallel.
+    - name: Check lint
+      run: npm run lint
+
+    - name: Check format
+      run: npm run format:check
+
     - name: Build component Sass
       run: npm run build:styling
 
@@ -29,14 +37,6 @@ jobs:
 
     - name: Compile test TypeScript
       run: npm run build:tests
-
-    # TODO(aomarks) Once b/144957560 is fixed, move lint and format into their
-    # own workflows or jobs so that they can run in parallel.
-    - name: Check lint
-      run: npm run lint
-
-    - name: Check format
-      run: npm run format:check
 
     - name: Unit tests
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,6 @@ jobs:
     - name: Lerna bootstrap
       run: npm run bootstrap
 
-    # TODO(aomarks) Once b/144957560 is fixed, move lint and format into their
-    # own workflows or jobs so that they can run in parallel.
-    - name: Check lint
-      run: npm run lint
-
     - name: Check format
       run: npm run format:check
 
@@ -34,6 +29,11 @@ jobs:
 
     - name: Compile component TypeScript
       run: npm run build:typescript
+
+    # TODO(aomarks) Once b/144957560 is fixed, move lint and format into their
+    # own workflows or jobs so that they can run in parallel.
+    - name: Check lint
+      run: npm run lint
 
     - name: Compile test TypeScript
       run: npm run build:tests


### PR DESCRIPTION
Make it take less time to get to the quick, dumb checks