### PR TITLE
feat(select): select can now select via value prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `mwc-ripple` now has CSS properties `--mdc-ripple-color`, `--mdc-ripple-fg-opacity`, and `--mdc-ripple-hover-opacity`
 - Added `RippleHandlers` to `mwc-ripple` to provide an easy integration point for calling ripple API.
 - Added `light` property to `mwc-ripple` to help style ripples on dark surfaces.
+- `mwc-select` can now select items by setting `mwc-select.value`.
 
 ### Changed
 

--- a/packages/list/src/mwc-list-foundation.ts
+++ b/packages/list/src/mwc-list-foundation.ts
@@ -509,7 +509,7 @@ export class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
             'MDCListFoundation: Expected array of index for checkbox based list but got number: ' +
             index);
       }
-      return this.isIndexInRange_(index);
+      return index === numbers.UNSET_INDEX || this.isIndexInRange_(index);
     } else {
       return false;
     }

--- a/packages/menu/src/mwc-menu-base.ts
+++ b/packages/menu/src/mwc-menu-base.ts
@@ -311,6 +311,22 @@ export abstract class MenuBase extends BaseElement {
     };
   }
 
+  protected async _getUpdateComplete() {
+    const listElement = this.listElement;
+    const listUpdateComplete =
+        listElement ? listElement.updateComplete : Promise.resolve();
+
+    const menuSurface = this.mdcRoot;
+    const surfaceUpdateComplete =
+        menuSurface ? menuSurface.updateComplete : Promise.resolve();
+
+    await Promise.all([
+      listUpdateComplete,
+      surfaceUpdateComplete,
+    ]);
+    await super._getUpdateComplete();
+  }
+
   protected onKeydown(evt: KeyboardEvent) {
     if (this.mdcFoundation) {
       this.mdcFoundation.handleKeydown(evt);

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -212,7 +212,7 @@ so the default slot has the same interface as the default slot of `mwc-list`.
 
 | Name                | Type             | Default | Description
 | ------------------- | ---------------- | ------- | -----------
-| `value`             | `string`         | `""`    | The select control's value determined by the `value` property of the currently selected list item.
+| `value`             | `string`         | `""`    | The select control's value determined by the `value` property of the currently selected list item. Setting value will attempt to select a list-item with the same value. If one does not match, it will set itself to `""` and the `index` to `-1`. Setting `value` before the list item is attached will not select the item.
 | `label`             | `string`         | `""`    | Sets floating label value. __NOTE:__ The label will not float if the selected item has a falsey value property.
 | `naturalWidth`      | `string`         | `false` | Sets the dropdown menu's width to `auto`.
 | `icon`              | `string`         | `""`    | Leading icon to display in select. See [`mwc-icon`](https://github.com/material-components/material-components-web-components/tree/master/packages/icon). _Note_: for proper list spacing, each list item must have `graphic="icon"` or `graphic="avatar"` to be set.

--- a/packages/select/src/mwc-select-base.ts
+++ b/packages/select/src/mwc-select-base.ts
@@ -611,7 +611,8 @@ export abstract class SelectBase extends FormElement {
 
     // init with value set
     if (this.value && !this.selected) {
-      if (this.slotElement?.assignedNodes({flatten: true}).length && !this.items.length) {
+      if (!this.items.length && this.slotElement &&
+          this.slotElement.assignedNodes({flatten: true}).length) {
         // Shady DOM initial render fix
         await new Promise((res) => requestAnimationFrame(res));
         await this.layout();


### PR DESCRIPTION
fixes #875

possible large performance slowdown on first render in the following case:

```html
<mwc-select value="nonempty">
  <div>Some assignedNode that is not a selectable item</div>
</mwc-select>
```

This slowdown was introduced because in the shady dom case, if you init with value, by first render callback you need your list items to be ready to select with `.value`. To prevent this wait on newer browsers, I limited it to the case where `value` was set, there are assigned nodes, but mwc-select does not know of any list-items. I felt that this would be a highly uncommon case as it is documented that setting `value` before the child is attached would not work as intended.