### PR TITLE
perf(select): perf improvements for select and sub elements

### DIFF
--- a/packages/list/src/mwc-list-base.ts
+++ b/packages/list/src/mwc-list-base.ts
@@ -451,10 +451,6 @@ export abstract class ListBase extends BaseElement {
     }
   }
 
-  protected onSlotChange() {
-    this.layout();
-  }
-
   protected onListItemConnected(e: Event) {
     const target = e.target as ListItemBase;
 

--- a/packages/menu/src/mwc-menu-base.ts
+++ b/packages/menu/src/mwc-menu-base.ts
@@ -311,22 +311,6 @@ export abstract class MenuBase extends BaseElement {
     };
   }
 
-  protected async _getUpdateComplete() {
-    const listElement = this.listElement;
-    const listUpdateComplete =
-        listElement ? listElement.updateComplete : Promise.resolve();
-
-    const menuSurface = this.mdcRoot;
-    const surfaceUpdateComplete =
-        menuSurface ? menuSurface.updateComplete : Promise.resolve();
-
-    await Promise.all([
-      listUpdateComplete,
-      surfaceUpdateComplete,
-    ]);
-    await super._getUpdateComplete();
-  }
-
   protected onKeydown(evt: KeyboardEvent) {
     if (this.mdcFoundation) {
       this.mdcFoundation.handleKeydown(evt);

--- a/packages/menu/src/mwc-menu-base.ts
+++ b/packages/menu/src/mwc-menu-base.ts
@@ -87,6 +87,8 @@ export abstract class MenuBase extends BaseElement {
   })
   defaultFocus: DefaultFocusState = 'LIST_ROOT';
 
+  protected _listUpdateComplete: null|Promise<unknown> = null;
+
   protected get listElement() {
     if (!this.listElement_) {
       this.listElement_ = this.renderRoot.querySelector('mwc-list');
@@ -340,6 +342,20 @@ export abstract class MenuBase extends BaseElement {
 
   protected onClosed() {
     this.open = false;
+  }
+
+  protected async _getUpdateComplete() {
+    await this._listUpdateComplete;
+    await super._getUpdateComplete();
+  }
+
+  protected async firstUpdated() {
+    const listElement = this.listElement;
+
+    if (listElement) {
+      this._listUpdateComplete = listElement.updateComplete;
+      await this._listUpdateComplete;
+    }
   }
 
   select(index: MWCListIndex) {

--- a/packages/menu/src/mwc-menu-surface-base.ts
+++ b/packages/menu/src/mwc-menu-surface-base.ts
@@ -55,32 +55,16 @@ export abstract class MenuSurfaceBase extends BaseElement {
   @observer(function(this: MenuSurfaceBase, isAbsolute: boolean) {
     if (this.mdcFoundation && !this.fixed) {
       this.mdcFoundation.setIsHoisted(isAbsolute);
-
-      this.saveOrRestoreAnchor(isAbsolute);
     }
   })
   absolute = false;
 
   @property({type: Boolean}) fullwidth = false;
 
-  @property({type: Object})
-  @observer(function(
-      this: MenuSurfaceBase, newAnchor: HTMLElement|null,
-      oldAnchor: HTMLElement|null) {
-    if (oldAnchor) {
-      oldAnchor.style.position = '';
-    }
-    if (newAnchor) {
-      newAnchor.style.position = 'relative';
-    }
-  })
-  anchor: HTMLElement|null = null;
-
   @property({type: Boolean})
   @observer(function(this: MenuSurfaceBase, isFixed: boolean) {
     if (this.mdcFoundation && !this.absolute) {
       this.mdcFoundation.setIsHoisted(isFixed);
-      this.saveOrRestoreAnchor(isFixed);
     }
   })
   fixed = false;
@@ -115,11 +99,12 @@ export abstract class MenuSurfaceBase extends BaseElement {
   quick = false;
 
   @property({type: Boolean, reflect: true})
-  @observer(function(this: MenuSurfaceBase, isOpen: boolean) {
+  @observer(function(this: MenuSurfaceBase, isOpen: boolean, wasOpen: boolean) {
     if (this.mdcFoundation) {
       if (isOpen) {
         this.mdcFoundation.open();
-      } else {
+        // wasOpen helps with first render (when it is `undefined`) perf
+      } else if (wasOpen !== undefined) {
         this.mdcFoundation.close();
       }
     }
@@ -138,9 +123,11 @@ export abstract class MenuSurfaceBase extends BaseElement {
   })
   corner: Corner = 'TOP_START';
 
+  anchor: HTMLElement|null = null;
+
   protected previouslyFocused: HTMLElement|Element|null = null;
   protected previousAnchor: HTMLElement|null = null;
-  protected onBodyClickBound: (evt: MouseEvent) => void = () => { /* init */ };
+  protected onBodyClickBound: (evt: MouseEvent) => void = () => undefined;
 
   render() {
     const classes = {
@@ -292,17 +279,6 @@ export abstract class MenuSurfaceBase extends BaseElement {
 
   protected deregisterBodyClick() {
     document.body.removeEventListener('click', this.onBodyClickBound);
-  }
-
-  protected saveOrRestoreAnchor(isAbsolute: boolean) {
-    if (isAbsolute) {
-      this.previousAnchor = this.anchor;
-      this.anchor = null;
-    }
-
-    if (!isAbsolute && !this.anchor && this.previousAnchor) {
-      this.anchor = this.previousAnchor;
-    }
   }
 
   close() {

--- a/packages/select/src/mwc-select-base.ts
+++ b/packages/select/src/mwc-select-base.ts
@@ -204,6 +204,7 @@ export abstract class SelectBase extends FormElement {
     cb: EventListenerOrEventListenerObject;
   })[] = [];
   protected onBodyClickBound: (evt: MouseEvent) => void = () => undefined;
+  protected _menuUpdateComplete: null|Promise<unknown> = null;
   protected get shouldRenderHelperText(): boolean {
     return !!this.helper || !!this.validationMessage;
   }
@@ -576,7 +577,19 @@ export abstract class SelectBase extends FormElement {
     this.formElement.setCustomValidity(message);
   }
 
+  protected async _getUpdateComplete() {
+    await this._menuUpdateComplete;
+    await super._getUpdateComplete();
+  }
+
   protected async firstUpdated() {
+    const menuElement = this.menuElement;
+
+    if (menuElement) {
+      this._menuUpdateComplete = menuElement.updateComplete;
+      await this._menuUpdateComplete;
+    }
+
     super.firstUpdated();
 
     this.mdcFoundation.isValid = () => true;

--- a/packages/select/src/mwc-select-base.ts
+++ b/packages/select/src/mwc-select-base.ts
@@ -203,9 +203,7 @@ export abstract class SelectBase extends FormElement {
     name: string;
     cb: EventListenerOrEventListenerObject;
   })[] = [];
-  protected onBodyClickBound: (evt: MouseEvent) => void = () => { /* init */ };
-  protected _outlineUpdateComplete: null|Promise<unknown> = null;
-  protected _menuUpdateComplete: null|Promise<unknown> = null;
+  protected onBodyClickBound: (evt: MouseEvent) => void = () => undefined;
   protected get shouldRenderHelperText(): boolean {
     return !!this.helper || !!this.validationMessage;
   }
@@ -578,27 +576,7 @@ export abstract class SelectBase extends FormElement {
     this.formElement.setCustomValidity(message);
   }
 
-  protected async _getUpdateComplete() {
-    await Promise.all([
-      this._outlineUpdateComplete,
-      this._menuUpdateComplete,
-    ]);
-    await super._getUpdateComplete();
-  }
-
   protected async firstUpdated() {
-    const menuElement = this.menuElement;
-    const outlineElement = this.outlineElement;
-    if (outlineElement) {
-      this._outlineUpdateComplete = outlineElement.updateComplete;
-      await this._outlineUpdateComplete;
-    }
-
-    if (menuElement) {
-      this._menuUpdateComplete = menuElement.updateComplete;
-      await this._menuUpdateComplete;
-    }
-
     super.firstUpdated();
 
     this.mdcFoundation.isValid = () => true;


### PR DESCRIPTION
None of these should affect the user hence no changelog.

Basically cleaned up some of the render cycle and deleted code that has been lying around a bit.

No real big changes: about a 2.5% perf improvement

**NOTE: Merge AFTER #969 as it is based off of that PR**

Before:
![image](https://user-images.githubusercontent.com/5981958/75949838-4bcdc480-5e5c-11ea-96ad-ae119c6741de.png)

After
![image](https://user-images.githubusercontent.com/5981958/75949976-c565b280-5e5c-11ea-9a41-ac0c2bf6856b.png)



This element is notably hammered by non-rendered ripples