### PR TITLE
[mwc-button] fix: Punctuation shows up as char reference.

### DIFF
--- a/packages/button/src/mwc-button-base.ts
+++ b/packages/button/src/mwc-button-base.ts
@@ -77,6 +77,7 @@ export class ButtonBase extends LitElement {
       'mdc-button--outlined': this.outlined,
       'mdc-button--dense': this.dense,
     };
+    this.label = this.label.replace(/(&#(\d+);)/g, (_match, _capture, charCode) => String.fromCharCode(charCode));
     return html`
       <button
           id="button"


### PR DESCRIPTION
This change prevents "Let's Chat" turning into "Let &_#_39;s chat" (without the _s).

This problem specifically shows up when rendering within Storybook.