### PR TITLE
Update lit-element to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+### Changed
+
+- Update `lit-element` dependency to `2.3.0` for all components.
+
+### Fixed
+
 ## [v0.14.0] - 2020-03-19
 
 ### Added

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -12,7 +12,7 @@
     "@material/base": "=6.0.0-canary.a88c8e4dc.0",
     "@material/dom": "=6.0.0-canary.a88c8e4dc.0",
     "@material/ripple": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -19,7 +19,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-icon": "^0.14.0",
     "@material/mwc-ripple": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -18,7 +18,7 @@
     "@material/checkbox": "=6.0.0-canary.a88c8e4dc.0",
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-ripple": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -20,7 +20,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/touch-target": "=6.0.0-canary.a88c8e4dc.0",
     "blocking-elements": "^0.1.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0",
     "wicg-inert": "^3.0.0"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -19,7 +19,7 @@
     "@material/drawer": "=6.0.0-canary.a88c8e4dc.0",
     "@material/mwc-base": "^0.14.0",
     "blocking-elements": "^0.1.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0",
     "wicg-inert": "^3.0.0"

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -19,7 +19,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-icon": "^0.14.0",
     "@material/mwc-ripple": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/floating-label": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@material/form-field": "=6.0.0-canary.a88c8e4dc.0",
     "@material/mwc-base": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/icon-button-toggle/package.json
+++ b/packages/icon-button-toggle/package.json
@@ -20,7 +20,7 @@
     "@material/mwc-icon": "^0.14.0",
     "@material/mwc-icon-button": "^0.14.0",
     "@material/mwc-ripple": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -19,7 +19,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-icon": "^0.14.0",
     "@material/mwc-ripple": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/line-ripple": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@material/linear-progress": "=6.0.0-canary.a88c8e4dc.0",
     "@material/mwc-base": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -15,7 +15,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-checkbox": "^0.14.0",
     "@material/mwc-radio": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -14,7 +14,7 @@
     "@material/menu-surface": "=6.0.0-canary.a88c8e4dc.0",
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-list": "^0.14.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -19,7 +19,7 @@
     "@material/notched-outline": "=6.0.0-canary.a88c8e4dc.0",
     "@material/shape": "=6.0.0-canary.a88c8e4dc.0",
     "@material/theme": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -18,7 +18,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-ripple": "^0.14.0",
     "@material/radio": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -18,7 +18,7 @@
     "@material/dom": "=6.0.0-canary.a88c8e4dc.0",
     "@material/mwc-base": "^0.14.0",
     "@material/ripple": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -21,7 +21,7 @@
     "@material/mwc-notched-outline": "^0.14.0",
     "@material/select": "=6.0.0-canary.a88c8e4dc.0",
     "@material/theme": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@material/mwc-base": "^0.14.0",
     "@material/slider": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@material/mwc-base": "^0.14.0",
     "@material/snackbar": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -15,7 +15,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-ripple": "^0.14.0",
     "@material/switch": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -20,7 +20,7 @@
     "@material/mwc-tab": "^0.14.0",
     "@material/mwc-tab-scroller": "^0.14.0",
     "@material/tab-bar": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@material/mwc-base": "^0.14.0",
     "@material/tab-indicator": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -19,7 +19,7 @@
     "@material/dom": "=6.0.0-canary.a88c8e4dc.0",
     "@material/mwc-base": "^0.14.0",
     "@material/tab-scroller": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -21,7 +21,7 @@
     "@material/mwc-ripple": "^0.14.0",
     "@material/mwc-tab-indicator": "^0.14.0",
     "@material/tab": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -13,7 +13,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-textfield": "^0.14.0",
     "@material/textfield": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -20,7 +20,7 @@
     "@material/shape": "=6.0.0-canary.a88c8e4dc.0",
     "@material/textfield": "=6.0.0-canary.a88c8e4dc.0",
     "@material/theme": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },

--- a/packages/top-app-bar-fixed/package.json
+++ b/packages/top-app-bar-fixed/package.json
@@ -19,7 +19,7 @@
     "@material/mwc-base": "^0.14.0",
     "@material/mwc-top-app-bar": "^0.14.0",
     "@material/top-app-bar": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@material/mwc-base": "^0.14.0",
     "@material/top-app-bar": "=6.0.0-canary.a88c8e4dc.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },


### PR DESCRIPTION
- lit-element 2.3.0 adds `@queryAsync` and `@queryAssignedNodes`, which
  we want to start using in MWC