### PR TITLE
Refactor checkbox to remove Foundation and ripple directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+### Changed
+
+- Refactor `mwc-checkbox`
+  - Remove usage of `MDCCheckboxFoundation`
+  - Replace `ripple-directive` with lazy `mwc-ripple`
+
+### Fixed
+
+- Fix property renaming issues with Closure Compiler
+  - Use `RippleAPI` interface between `RippleHandlers` and `mwc-ripple`
+  - Use `RippleInterface` interface for `ripple-directive`
 
 ## [v0.14.1] - 2020-03-23
 

--- a/packages/base/src/form-element.ts
+++ b/packages/base/src/form-element.ts
@@ -16,25 +16,17 @@ limitations under the License.
 */
 
 import {addHasRemoveClass, BaseElement, CustomEventListener, EventType, SpecificEventListener} from './base-element.js';
+import {HTMLElementWithRipple, RippleInterface} from './utils.js';
 
 export {
   addHasRemoveClass,
   BaseElement,
   CustomEventListener,
   EventType,
-  SpecificEventListener
+  HTMLElementWithRipple,
+  RippleInterface,
+  SpecificEventListener,
 };
-
-export interface HTMLElementWithRipple extends HTMLElement {
-  ripple?: RippleInterface;
-}
-
-export interface RippleInterface {
-  activate: (e?: Event) => void;
-  deactivate: () => void;
-  handleFocus: () => void;
-  handleBlur: () => void;
-}
 
 export abstract class FormElement extends BaseElement {
   /**

--- a/packages/base/src/utils.ts
+++ b/packages/base/src/utils.ts
@@ -114,3 +114,14 @@ export const doesElementContainFocus = (element: HTMLElement): boolean => {
 
   return composedPath.indexOf(element) !== -1;
 };
+
+export interface HTMLElementWithRipple extends HTMLElement {
+  ripple?: RippleInterface;
+}
+
+export interface RippleInterface {
+  activate: (e?: Event) => void;
+  deactivate: () => void;
+  handleFocus: () => void;
+  handleBlur: () => void;
+}

--- a/packages/checkbox/src/mwc-checkbox.scss
+++ b/packages/checkbox/src/mwc-checkbox.scss
@@ -15,9 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import '@material/checkbox/mdc-checkbox.scss';
+@import '@material/checkbox/mixins';
 
-@include mdc-ripple-common(mdc-feature-all());
+@include mdc-checkbox-without-ripple(mdc-feature-all());
 
 :host {
   outline: none;
@@ -27,6 +27,10 @@ limitations under the License.
 .mdc-checkbox {
   .mdc-checkbox__native-control:focus ~ .mdc-checkbox__background::before {
     background-color: var(--mdc-checkbox-unchecked-color, #{$mdc-checkbox-border-color});
+  }
+  /* disable non-upgraded ripple on checkbox backround */
+  .mdc-checkbox__background::before {
+    content: none;
   }
 }
 

--- a/packages/ripple/src/mwc-ripple-base.ts
+++ b/packages/ripple/src/mwc-ripple-base.ts
@@ -19,10 +19,11 @@ import {MDCRippleAdapter} from '@material/ripple/adapter.js';
 import MDCRippleFoundation from '@material/ripple/foundation.js';
 import {html, property, query} from 'lit-element';
 import {classMap} from 'lit-html/directives/class-map.js';
-import {styleMap} from 'lit-html/directives/style-map';
+import {styleMap} from 'lit-html/directives/style-map.js';
+import {RippleAPI} from './ripple-handlers.js';
 
 /** @soyCompatible */
-export class RippleBase extends BaseElement {
+export class RippleBase extends BaseElement implements RippleAPI {
   @query('.mdc-ripple-surface') mdcRoot!: HTMLElement;
 
   @property({type: Boolean}) primary = false;

--- a/packages/ripple/src/ripple-handlers.ts
+++ b/packages/ripple/src/ripple-handlers.ts
@@ -14,7 +14,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {Ripple} from './mwc-ripple.js';
+
+import {RippleInterface} from '@material/mwc-base/utils.js';
+
+export interface RippleAPI extends RippleInterface {
+  handleMouseEnter: () => void;
+  handleMouseLeave: () => void;
+}
 
 /**
  * Class that encapsulates the events handlers for `mwc-ripple`
@@ -39,7 +45,7 @@ import {Ripple} from './mwc-ripple.js';
  * }
  * ```
  */
-export class RippleHandlers {
+export class RippleHandlers implements RippleAPI {
   activate: (ev?: Event) => void;
   deactivate: () => void;
   handleFocus: () => void;
@@ -49,7 +55,7 @@ export class RippleHandlers {
 
   constructor(
       /** Function that returns a `mwc-ripple` */
-      rippleFn: () => Promise<Ripple|null>) {
+      rippleFn: () => Promise<RippleAPI|null>) {
     this.activate = (ev?: Event) => {
       rippleFn().then((r) => {
         r && r.activate(ev);


### PR DESCRIPTION
Refactor checkbox to remove Foundation and ripple directive

- Remove checkbox adapter and foundation
- Replace ripple directive with lazy `mwc-ripple`
- Fix Closure Compiler renaming issues

Related #892
Related #894
Related #882
