### PR TITLE
docs(select): fix broken table about fired events

### DIFF
--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -253,24 +253,8 @@ Name                                          | Description
 | ---------- | -------------------- | ----------------- | -------------------- |
 | `opened`   | `mwc-select-surface` | none              | Fired menu opens.    |
 | `closed`   | `mwc-select-surface` | none              | Fired menu closes.   |
-| `action`   | `mwc-list`           | `ActionDetail`*   | Fired when a         |
-:            :                      :                   : selection has been   :
-:            :                      :                   : made via click or    :
-:            :                      :                   : keyboard aciton.     :
-| `selected` | `mwc-list`           | `SelectedDetail`* | Fired when a         |
-:            :                      :                   : selection has been   :
-:            :                      :                   : made. `index` is the :
-:            :                      :                   : selected index (will :
-:            :                      :                   : be of type           :
-:            :                      :                   : `Set<number>` if     :
-:            :                      :                   : multi and `number`   :
-:            :                      :                   : if single), and      :
-:            :                      :                   : `diff` (of type      :
-:            :                      :                   : `IndexDiff`**)       :
-:            :                      :                   : represents the diff  :
-:            :                      :                   : of added and removed :
-:            :                      :                   : indices from         :
-:            :                      :                   : previous selection.  :
+| `action`   | `mwc-list`           | `ActionDetail`*   | Fired when a selection has been made via click or keyboard aciton. |
+| `selected` | `mwc-list`           | `SelectedDetail`* | Fired when a selection has been made. `index` is the selected index (will be of type `Set<number>` if multi and `number`if single), and `diff` (of type `IndexDiff`**) represents the diff of added and removed indices from previous selection. |
 
 \* See
 [`mwc-list`'s Events section](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-2)


### PR DESCRIPTION
While viewing the select-package on npm, I ran over the broken table. Unfortunately, the used notation is not supported on npm.
I updated the README to use the same notation as in other README-files.