### PR TITLE
docs(select): fix broken table about fired events

### DIFF
--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -253,24 +253,8 @@ Name                                          | Description
 | ---------- | -------------------- | ----------------- | -------------------- |
 | `opened`   | `mwc-select-surface` | none              | Fired menu opens.    |
 | `closed`   | `mwc-select-surface` | none              | Fired menu closes.   |
-| `action`   | `mwc-list`           | `ActionDetail`*   | Fired when a         |
-:            :                      :                   : selection has been   :
-:            :                      :                   : made via click or    :
-:            :                      :                   : keyboard aciton.     :
-| `selected` | `mwc-list`           | `SelectedDetail`* | Fired when a         |
-:            :                      :                   : selection has been   :
-:            :                      :                   : made. `index` is the :
-:            :                      :                   : selected index (will :
-:            :                      :                   : be of type           :
-:            :                      :                   : `Set<number>` if     :
-:            :                      :                   : multi and `number`   :
-:            :                      :                   : if single), and      :
-:            :                      :                   : `diff` (of type      :
-:            :                      :                   : `IndexDiff`**)       :
-:            :                      :                   : represents the diff  :
-:            :                      :                   : of added and removed :
-:            :                      :                   : indices from         :
-:            :                      :                   : previous selection.  :
+| `action`   | `mwc-list`           | `ActionDetail`*   | Fired when a selection has been made via click or keyboard aciton. |
+| `selected` | `mwc-list`           | `SelectedDetail`* | Fired when a selection has been made. `index` is the selected index (will be of type `Set<number>` if multi and `number`if single), and `diff` (of type `IndexDiff`**) represents the diff of added and removed indices from previous selection. |
 
 \* See
 [`mwc-list`'s Events section](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-2)


### PR DESCRIPTION
While reading the README of select on npm I ran into a buggy table. Unfortunately, npm doesn't support the notation, which was in use, therefore I changed it to the same notation used in the other README-files.