### PR TITLE
Refactor button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added --mdc-menu-z-index to menu-surface
 - Added surface/on-surface theme properties for mwc-switch
+- Added overrides for ripple focus and hover opacities
+  - `--mdc-ripple-focus-opacity` and `--mdc-ripple-hover-opacity` respectively
 
 ### Changed
 
 - Refactor `mwc-checkbox`
   - Remove usage of `MDCCheckboxFoundation`
+  - Replace `ripple-directive` with lazy `mwc-ripple`
+- Refactor `mwc-button`
   - Replace `ripple-directive` with lazy `mwc-ripple`
 
 ### Fixed

--- a/packages/button/src/mwc-button-base.ts
+++ b/packages/button/src/mwc-button-base.ts
@@ -15,12 +15,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-icon';
+import '@material/mwc-ripple/mwc-ripple.js';
 
-import {HTMLElementWithRipple} from '@material/mwc-base/form-element';
-import {rippleNode} from '@material/mwc-ripple/ripple-directive.js';
-import {html, LitElement, property, query} from 'lit-element';
+import {Ripple} from '@material/mwc-ripple/mwc-ripple.js';
+import {RippleHandlers} from '@material/mwc-ripple/ripple-handlers.js';
+import {html, internalProperty, LitElement, property, query, queryAsync} from 'lit-element';
 import {classMap} from 'lit-html/directives/class-map.js';
 
+/** @soyCompatible */
 export class ButtonBase extends LitElement {
   @property({type: Boolean}) raised = false;
 
@@ -32,7 +34,7 @@ export class ButtonBase extends LitElement {
 
   @property({type: Boolean, reflect: true}) disabled = false;
 
-  @property({type: Boolean}) trailingIcon = false;
+  @property({type: Boolean, attribute: 'trailingicon'}) trailingIcon = false;
 
   @property({type: Boolean, reflect: true}) fullwidth = false;
 
@@ -40,7 +42,26 @@ export class ButtonBase extends LitElement {
 
   @property({type: String}) label = '';
 
-  @query('#button') buttonElement!: HTMLElementWithRipple;
+  @query('#button') buttonElement!: HTMLElement;
+
+  @queryAsync('mwc-ripple') ripple!: Promise<Ripple|null>;
+
+  @internalProperty() protected shouldRenderRipple = false;
+
+  protected rippleHandlers: RippleHandlers = new RippleHandlers(() => {
+    this.shouldRenderRipple = true;
+    return this.ripple;
+  });
+
+  /** @soyCompatible */
+  protected renderRipple() {
+    const filled = this.raised || this.unelevated;
+    return html`${
+        this.shouldRenderRipple ?
+            html`<mwc-ripple .primary="${!filled}" .disabled="${
+                this.disabled}"></mwc-ripple>"` :
+            ''}`;
+  }
 
   protected createRenderRoot() {
     return this.attachShadow({mode: 'open', delegatesFocus: true});
@@ -49,11 +70,7 @@ export class ButtonBase extends LitElement {
   focus() {
     const buttonElement = this.buttonElement;
     if (buttonElement) {
-      const ripple = buttonElement.ripple;
-      if (ripple) {
-        ripple.handleFocus();
-      }
-
+      this.rippleHandlers.handleFocus();
       buttonElement.focus();
     }
   }
@@ -61,16 +78,14 @@ export class ButtonBase extends LitElement {
   blur() {
     const buttonElement = this.buttonElement;
     if (buttonElement) {
-      const ripple = buttonElement.ripple;
-      if (ripple) {
-        ripple.handleBlur();
-      }
-
+      this.rippleHandlers.handleBlur();
       buttonElement.blur();
     }
   }
 
+  /** @soyCompatible */
   protected render() {
+    /** @classMap */
     const classes = {
       'mdc-button--raised': this.raised,
       'mdc-button--unelevated': this.unelevated,
@@ -82,32 +97,61 @@ export class ButtonBase extends LitElement {
           id="button"
           class="mdc-button ${classMap(classes)}"
           ?disabled="${this.disabled}"
-          aria-label="${this.label || this.icon}">
-        <div class="mdc-button__ripple"></div>
+          aria-label="${this.label || this.icon}"
+          @focus="${this.handleRippleFocus}"
+          @blur="${this.handleRippleBlur}"
+          @mousedown="${this.handleRippleActivate}"
+          @mouseup="${this.handleRippleDeactivate}"
+          @mouseenter="${this.handleRippleMouseEnter}"
+          @mouseleave="${this.handleRippleMouseLeave}"
+          @touchstart="${this.handleRippleActivate}"
+          @touchend="${this.handleRippleDeactivate}"
+          @touchcancel="${this.handleRippleDeactivate}">
+        ${this.renderRipple()}
         <span class="leading-icon">
           <slot name="icon">
-            ${this.icon && !this.trailingIcon ? this.renderIcon(this.icon) : ''}
+            ${this.icon && !this.trailingIcon ? this.renderIcon() : ''}
           </slot>
         </span>
         <span class="mdc-button__label">${this.label}</span>
         <slot></slot>
         <span class="trailing-icon">
           <slot name="trailingIcon">
-            ${this.icon && this.trailingIcon ? this.renderIcon(this.icon) : ''}
+            ${this.icon && this.trailingIcon ? this.renderIcon() : ''}
           </slot>
         </span>
       </button>`;
   }
 
-  protected renderIcon(icon: string) {
+  /** @soyCompatible */
+  protected renderIcon() {
     return html`
-      <mwc-icon class="mdc-button__icon">
-        ${icon}
-      </mwc-icon>`;
+    <mwc-icon class="mdc-button__icon">
+      ${this.icon}
+    </mwc-icon>`;
   }
 
-  firstUpdated() {
-    this.buttonElement.ripple =
-        rippleNode({surfaceNode: this.buttonElement, unbounded: false});
+  private handleRippleActivate(evt?: Event) {
+    this.rippleHandlers.activate(evt);
+  }
+
+  private handleRippleDeactivate() {
+    this.rippleHandlers.deactivate();
+  }
+
+  private handleRippleMouseEnter() {
+    this.rippleHandlers.handleMouseEnter();
+  }
+
+  private handleRippleMouseLeave() {
+    this.rippleHandlers.handleMouseLeave();
+  }
+
+  private handleRippleFocus() {
+    this.rippleHandlers.handleFocus();
+  }
+
+  private handleRippleBlur() {
+    this.rippleHandlers.handleBlur();
   }
 }

--- a/packages/button/src/mwc-button.scss
+++ b/packages/button/src/mwc-button.scss
@@ -16,9 +16,10 @@ limitations under the License.
 */
 
 @import '@material/mwc-base/src/elevation.scss';
-@import '@material/button/mdc-button.scss';
+@import '@material/button/mixins';
 
-@include mdc-ripple-common(mdc-feature-all());
+@include mdc-button-without-ripple();
+@include mdc-button-theme-baseline();
 
 .trailing-icon,
 .leading-icon, {
@@ -97,19 +98,32 @@ limitations under the License.
   &.mdc-button--raised,
   &.mdc-button--unelevated {
     @include mdc-button-horizontal-padding(var(--mdc-button-horizontal-padding, #{$mdc-button-contained-horizontal-padding}));
+    // NOTE(dfreedm): Replace hardcoded opacities when
+    // https://github.com/material-components/material-components-web-components/issues/1072
+    // is resolved
+    mwc-ripple {
+      --mdc-ripple-color: var(--mdc-theme-on-primary, #{mdc-theme-prop-value(on-primary)});
+      --mdc-ripple-hover-opacity: .08;
+      --mdc-ripple-fg-opacity: .24;
+      --mdc-ripple-focus-opacity: .24;
+    }
   }
 
   &.mdc-button--outlined {
     @include mdc-button-outline-width-var-aware(var(--mdc-button-outline-width, #{$mdc-button-outlined-border-width}), var(--mdc-button-horizontal-padding, #{$mdc-button-contained-horizontal-padding}));
     border-color: var(--mdc-button-outline-color, var(--mdc-theme-primary, #{mdc-theme-prop-value(primary)}));
+    mwc-ripple {
+      top: -1px;
+      left: -1px;
+      border: 1px solid transparent;
+      --mdc-ripple-surface-top: -1px;
+      --mdc-ripple-surface-left: -1px;
+      --mdc-ripple-surface-border: 1px solid transparent;
+    }
   }
 
   &.mdc-button--dense {
     @include mdc-button-density(-2);
-  }
-
-  .mdc-button__ripple {
-    border-radius: 0;
   }
 }
 

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -19,6 +19,7 @@ import {customElement} from 'lit-element';
 import {ButtonBase} from './mwc-button-base.js';
 import {style} from './mwc-button-css.js';
 
+/** @soyCompatible */
 @customElement('mwc-button')
 export class Button extends ButtonBase {
   static styles = style;

--- a/packages/button/src/test/mwc-button.test.ts
+++ b/packages/button/src/test/mwc-button.test.ts
@@ -93,17 +93,17 @@ suite('mwc-button', () => {
 
     test('focus fn highlights and blurs', async () => {
       const focusedClass = 'mdc-ripple-upgraded--background-focused';
-      const nativeButton =
-          element.shadowRoot!.querySelector('#button') as HTMLButtonElement;
-      assert.isFalse(nativeButton.classList.contains(focusedClass));
       element.focus();
+      const rippleElement = await element.ripple;
+      const nativeRipple = rippleElement!.shadowRoot!.querySelector(
+                               '.mdc-ripple-surface') as HTMLDivElement;
       await element.requestUpdate();
       await rafPromise();
-      assert.isTrue(nativeButton.classList.contains(focusedClass));
+      assert.isTrue(nativeRipple.classList.contains(focusedClass));
       element.blur();
       await element.requestUpdate();
       await rafPromise();
-      assert.isFalse(nativeButton.classList.contains(focusedClass));
+      assert.isFalse(nativeRipple.classList.contains(focusedClass));
     });
 
     teardown(async () => {

--- a/packages/ripple/src/mwc-ripple-base.ts
+++ b/packages/ripple/src/mwc-ripple-base.ts
@@ -34,8 +34,6 @@ export class RippleBase extends BaseElement implements RippleAPI {
 
   @property({type: Boolean}) disabled = false;
 
-  @property({type: Boolean}) light = false;
-
   @property({attribute: false}) private hovering = false;
 
   @property({attribute: false}) private bgFocused = false;
@@ -191,7 +189,6 @@ export class RippleBase extends BaseElement implements RippleAPI {
       'primary': this.primary,
       'accent': this.accent,
       'disabled': this.disabled,
-      'light': this.light,
     };
     return html`
         <div class="mdc-ripple-surface mdc-ripple-upgraded ${classMap(classes)}"

--- a/packages/ripple/src/mwc-ripple.scss
+++ b/packages/ripple/src/mwc-ripple.scss
@@ -18,8 +18,34 @@ limitations under the License.
 @use '@material/ripple';
 @import '@material/ripple/mdc-ripple.scss';
 
+@mixin sizing() {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+
+  @include mdc-theme-prop(top, (
+    varname: --mdc-ripple-surface-top,
+    fallback: 0
+  ));
+
+  @include mdc-theme-prop(left, (
+    varname: --mdc-ripple-surface-left,
+    fallback: 0
+  ));
+
+  @include mdc-theme-prop(border, (
+    varname: --mdc-ripple-surface-border,
+    fallback: initial
+  ));
+}
+
 :host {
+  display: block;
   --mdc-ripple-fg-opacity: #{map-get($mdc-ripple-dark-ink-opacities, press)};
+  @include sizing();
 }
 
 /*
@@ -42,12 +68,7 @@ limitations under the License.
 }
 
 .mdc-ripple-surface {
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  @include sizing();
 
   &.mdc-ripple-upgraded {
     /* use inherit keyword to "reset" definition from mdc-ripple styles */
@@ -58,6 +79,13 @@ limitations under the License.
     varname: --mdc-ripple-color,
     fallback: #000
   ));
+
+  &.mdc-ripple-upgraded--background-focused::before {
+    @include mdc-theme-prop(opacity, (
+      varname: --mdc-ripple-focus-opacity,
+      fallback: map-get($mdc-ripple-dark-ink-opacities, focus)
+    ));
+  }
 }
 
 .hover::before {
@@ -65,27 +93,4 @@ limitations under the License.
     varname: --mdc-ripple-hover-opacity,
     fallback: map-get($mdc-ripple-dark-ink-opacities, hover)
   ));
-}
-
-/*
- * Overrides for "light" ripples on dark surfaces
- */
-.light {
-  --mdc-ripple-fg-opacity: #{map-get($mdc-ripple-light-ink-opacities, press)};
-  --mdc-ripple-color: #fff;
-
-  &.hover::before {
-    @include mdc-theme-prop(opacity, (
-      varname: --mdc-ripple-hover-opacity,
-      fallback: map-get($mdc-ripple-light-ink-opacities, hover)
-    ));
-  }
-
-  &.primary {
-    --mdc-ripple-color: var(--mdc-theme-on-primary, #{mdc-theme-prop-value(on-primary)});
-  }
-
-  &.accent {
-    --mdc-ripple-color: var(--mdc-theme-on-secondary, #{mdc-theme-prop-value(on-secondary)});
-  }
 }


### PR DESCRIPTION
Refactor button

- Replace `ripple-directive` with lazy `mwc-ripple`
- Expose `--mwc-ripple-focus-opacity` and `--mwc-ripple-hover-opacity` for theming ripple focus and hover state

Related #894
Related #892
