### PR TITLE
fix(select): Strip byte order mark in CSS compilation

### DIFF
--- a/scripts/sass-render/index.js
+++ b/scripts/sass-render/index.js
@@ -37,7 +37,13 @@ async function sassToCss(sassFile) {
     },
     outputStyle: 'compressed',
   });
-  return result.css.toString();
+    
+  // Strip any Byte Order Marking from output CSS
+  let cssStr = result.css.toString();
+  if (cssStr.charCodeAt(0) === 0xFEFF) {
+    cssStr = cssStr.substr(1);
+  }
+  return cssStr;
 }
 
 async function sassRender(sourceFile, templateFile, outputFile) {


### PR DESCRIPTION
This was causing problems where the first rule of the CSS output (with the Byte Order Marking in its prefix) would be discarded.

Closes #1275 