### PR TITLE
Sync lit-analyzer settings with internal

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,35 @@
       "@material/mwc-*": ["./*/src"]
     },
     "composite": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "plugins": [
+      {
+        "name": "ts-lit-plugin",
+        "rules": {
+          "no-unknown-tag-name": "error",
+          "no-unclosed-tag": "error",
+          "no-unknown-property": "error",
+          "no-unintended-mixed-binding": "error",
+          "no-invalid-boolean-binding": "error",
+          "no-expressionless-property-binding": "error",
+          "no-noncallable-event-binding": "error",
+          "no-boolean-in-attribute-binding": "error",
+          "no-complex-attribute-binding": "error",
+          "no-nullable-attribute-binding": "error",
+          "no-incompatible-type-binding": "error",
+          "no-invalid-directive-binding": "error",
+          "no-incompatible-property-type": "error",
+          "no-unknown-property-converter": "error",
+          "no-invalid-attribute-name": "error",
+          "no-invalid-tag-name": "error",
+
+          "no-unknown-attribute": "off",
+          "no-unknown-event": "off",
+          "no-unknown-slot": "off",
+          "no-invalid-css": "off"
+        }
+      }
+    ]
   },
   "include": [
     "custom_typings/**/*.ts",


### PR DESCRIPTION
Internally, we disable a few checks in lit-analyzer for easier integration of other tools

`no-unknown-attribute` is disabled for teams to add app-specific attributes.

Incidentally, this also fixes our issue with https://github.com/runem/lit-analyzer/pull/107