### PR TITLE
Prevent mwc-list-item selectedText from including text from font liga…

### DIFF
--- a/demos/select/index.html
+++ b/demos/select/index.html
@@ -135,6 +135,20 @@ limitations under the License.
     </mwc-select>
     <div>Value: <span id="disabledOptionsValue"></span></div>
 
+    <h2>Options with Icons</h2>
+    <mwc-select label="Option Icons">
+      <mwc-list-item></mwc-list-item>
+      <mwc-list-item graphic="avatar" value="1">
+        Option 1
+        <mwc-icon slot="graphic">lightbulb</mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item graphic="avatar" icon="add" value="2">
+        <div>Option 2</div>
+        <mwc-icon slot="graphic">add</mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item value="3">Option 3 (no icon)</mwc-list-item>
+    </mwc-select>
+
     <h2>Natural Menu Width</h2>
 
     <style>

--- a/packages/list/src/mwc-list-item-base.ts
+++ b/packages/list/src/mwc-list-item-base.ts
@@ -154,13 +154,15 @@ export class ListItemBase extends LitElement {
       ];
 
   get text() {
-    const textContent = this.textContent;
-
-    return textContent ? this.renderRoot.querySelectorAll('slot')[1].assignedNodes().reduce(
+    const primaryTextSlot = this.renderRoot.querySelector('.mdc-list-item__text')?.querySelector('slot');
+    if (!primaryTextSlot) {
+      return '';
+    }
+    return primaryTextSlot.assignedNodes().reduce(
       (totalString, partialStringElem)=>{
         totalString = totalString + partialStringElem.textContent;
         return totalString;
-      }, '').trim(): '';
+      }, '').trim();
   }
 
   render() {

--- a/packages/list/src/mwc-list-item-base.ts
+++ b/packages/list/src/mwc-list-item-base.ts
@@ -156,7 +156,11 @@ export class ListItemBase extends LitElement {
   get text() {
     const textContent = this.textContent;
 
-    return textContent ? textContent.trim() : '';
+    return textContent ? this.renderRoot.querySelectorAll('slot')[1].assignedNodes().reduce(
+      (totalString, partialStringElem)=>{
+        totalString = totalString + partialStringElem.textContent;
+        return totalString;
+      }, '').trim(): '';
   }
 
   render() {


### PR DESCRIPTION
…tures of slotted icons

Problem: the `selectedText` property of mwc-list-item returns the text content of all slots, including the font ligatures of slotted mwc-icons. This currently prevents us from using slotted icons with mwc-list-items inside of an mwc-select because the displayed `selectedText` will also include the font ligatures' text.

Fix: Return only the text of the default/primary slot, not that of the icon slots.

I also added "Options with Icons" to the mwc-select demo page.