### PR TITLE
fix(demos): styles on FF

### DIFF
--- a/demos/button/index.html
+++ b/demos/button/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-button {
       margin: 20px;

--- a/demos/checkbox/index.html
+++ b/demos/checkbox/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     .styled {
       background-color: #363636;

--- a/demos/dialog/index.html
+++ b/demos/dialog/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     body {
       min-height: calc(100vh - 4em);

--- a/demos/drawer/index.html
+++ b/demos/drawer/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     iframe {
       margin-bottom: 36px;

--- a/demos/drawer_dismissible/index.html
+++ b/demos/drawer_dismissible/index.html
@@ -28,11 +28,10 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="../drawer/drawer.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+  <link href="../drawer/drawer.css" rel="stylesheet">
 </head>
 <body>
   <mwc-drawer hasHeader type="dismissible">

--- a/demos/drawer_modal/index.html
+++ b/demos/drawer_modal/index.html
@@ -27,11 +27,10 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="../drawer/drawer.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+  <link href="../drawer/drawer.css" rel="stylesheet">
 </head>
 <body>
   <mwc-drawer hasHeader type="modal">

--- a/demos/drawer_standard/index.html
+++ b/demos/drawer_standard/index.html
@@ -27,11 +27,10 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="../drawer/drawer.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+  <link href="../drawer/drawer.css" rel="stylesheet">
 </head>
 <body>
   <mwc-drawer hasHeader>

--- a/demos/drawer_standard_no_header/index.html
+++ b/demos/drawer_standard_no_header/index.html
@@ -27,11 +27,10 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="../drawer/drawer.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+  <link href="../drawer/drawer.css" rel="stylesheet">
 </head>
 <body>
   <mwc-drawer>

--- a/demos/fab/index.html
+++ b/demos/fab/index.html
@@ -29,10 +29,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-fab {
       margin-right: 50px;

--- a/demos/formfield/index.html
+++ b/demos/formfield/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
 </head>
 <body class="unresolved">
   <demo-header component="Formfield" package="formfield"></demo-header>

--- a/demos/icon-button-toggle/index.html
+++ b/demos/icon-button-toggle/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-icon-button-toggle {
       margin: 20px;

--- a/demos/icon-button/index.html
+++ b/demos/icon-button/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-icon-button {
       padding: 20px;

--- a/demos/icon/index.html
+++ b/demos/icon/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     .color-size {
       color: tomato;

--- a/demos/index.html
+++ b/demos/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="./shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="./shared/ie-style-transform.js"></script>
+  <link href="./shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
 </head>
 <body>
   <demo-view></demo-view>

--- a/demos/linear-progress/index.html
+++ b/demos/linear-progress/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-linear-progress {
       width: 50%;

--- a/demos/list/index.html
+++ b/demos/list/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-list {
       border: 1px solid lightgray;

--- a/demos/menu/index.html
+++ b/demos/menu/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     body {
       height: 90vh;

--- a/demos/radio/index.html
+++ b/demos/radio/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     .styled {
       display: inline-block;

--- a/demos/ripple/index.html
+++ b/demos/ripple/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     .demo-box {
       min-width: 128px;

--- a/demos/select/index.html
+++ b/demos/select/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     body {
       min-height: calc(100vh - 4em);

--- a/demos/shared/ie-style-transform.js
+++ b/demos/shared/ie-style-transform.js
@@ -1,8 +1,0 @@
-const styles = document.head.querySelectorAll('link[rel="preload"][as="style"]');
-
-for (let i = 0; i < styles.length; i++) {
-  const style = styles[i];
-  style.removeAttribute('onload');
-  style.setAttribute('rel', 'stylesheet');
-  style.removeAttribute('as');
-}

--- a/demos/slider/index.html
+++ b/demos/slider/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     .demo-container {
       display: flex;

--- a/demos/snackbar/index.html
+++ b/demos/snackbar/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     .demo-group {
       display: flex;

--- a/demos/switch/index.html
+++ b/demos/switch/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     .styled {
       display: flex;

--- a/demos/tabs/index.html
+++ b/demos/tabs/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     iframe {
       border: 1px solid gray;

--- a/demos/tabs_rtl/index.html
+++ b/demos/tabs_rtl/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     main {
       margin-top: 0;

--- a/demos/textarea/index.html
+++ b/demos/textarea/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-textarea {
       min-width: 250px;

--- a/demos/textfield/index.html
+++ b/demos/textfield/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     mwc-textfield {
       min-width: 240px;

--- a/demos/top-app-bar-fixed/index.html
+++ b/demos/top-app-bar-fixed/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     iframe {
       display: block;

--- a/demos/top-app-bar-fixed_iframe/index.html
+++ b/demos/top-app-bar-fixed_iframe/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     #content {
       margin-top: 8px;

--- a/demos/top-app-bar/index.html
+++ b/demos/top-app-bar/index.html
@@ -28,10 +28,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     iframe {
       display: block;

--- a/demos/top-app-bar_iframe/index.html
+++ b/demos/top-app-bar_iframe/index.html
@@ -27,10 +27,9 @@ limitations under the License.
       opacity: 0;
     }
   </style>
-  <link rel="preload" href="../shared/shared.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <script nomodule src="../shared/ie-style-transform.js"></script>
+  <link href="../shared/shared.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
   <style>
     #content {
       margin-top: 8px;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -182,24 +182,5 @@ export default [
       }),
     ],
   },
-  {
-    // styles perf improvement doesn't work on IE
-    input: 'demos/shared/ie-style-transform.js',
-    output: {
-      file: 'dist/demos/shared/ie-style-transform.js',
-      format: 'iife',
-      sourcemap: false,
-    },
-    plugins: [
-      strip({
-        functions: ['console.log'],
-      }),
-      minifyHTML(),
-      terser(),
-      babel({
-        presets: [['@babel/preset-env', {modules: false}]]
-      }),
-    ],
-  },
   ...configs,
 ];


### PR DESCRIPTION
preload styles trick no longer works on FF. Will have to think of another fix to these render-blocking styles as icons tank our lighthouse scores