### PR TITLE
chore(slider): Stop updating MDC slider dep.

### DIFF
--- a/scripts/bump-all-mdc-web-deps.ts
+++ b/scripts/bump-all-mdc-web-deps.ts
@@ -54,6 +54,12 @@ function main() {
     const updateDependencies = (dependencies: Record<string, string>) => {
       for (const [pkg, oldVersion] of Object.entries(dependencies)) {
         if (isMdcWebPackage(pkg)) {
+          // TODO(b/156658489): Keep MDC slider dep pinned until
+          // we've updated to the M2 slider.
+          if (pkg.startsWith('@material/slider') {
+            continue;
+          }
+              
           if (oldVersion !== newVersion) {
             dependencies[pkg] = newVersion;
             console.log(


### PR DESCRIPTION
We'll remove this check once we've updated to the new M2 slider.