### PR TITLE
Refactor radio replace ripple with lazy mwc-ripple

### DIFF
--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -240,23 +240,23 @@ export class RadioBase extends FormElement {
     this.rippleHandlers.startPress(event);
   }
 
-  private handleRippleDeactivate() {
+  protected handleRippleDeactivate() {
     this.rippleHandlers.endPress();
   }
 
-  private handleRippleMouseEnter() {
+  protected handleRippleMouseEnter() {
     this.rippleHandlers.startHover();
   }
 
-  private handleRippleMouseLeave() {
+  protected handleRippleMouseLeave() {
     this.rippleHandlers.endHover();
   }
 
-  private handleRippleFocus() {
+  protected handleRippleFocus() {
     this.rippleHandlers.startFocus();
   }
 
-  private handleRippleBlur() {
+  protected handleRippleBlur() {
     this.rippleHandlers.endFocus();
   }
 }

--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -164,15 +164,14 @@ export class RadioBase extends FormElement {
   });
 
   protected renderRipple() {
-    if (this.shouldRenderRipple) {
-      return html`
+    return html`${
+        this.shouldRenderRipple ? html`
         <mwc-ripple 
           .accent="${this.checked}" 
           .disabled="${this.disabled}" 
           unbounded>
-        </mwc-ripple>`;
-    }
-    return html``;
+        </mwc-ripple>` :
+                                  html``}`;
   }
 
   private _changeHandler() {

--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -142,7 +142,6 @@ export class RadioBase extends FormElement {
 
   focus() {
     this.focusNative();
-    this.handleRippleFocus();
   }
 
   focusNative() {
@@ -179,8 +178,16 @@ export class RadioBase extends FormElement {
   }
 
   private _focusHandler() {
+    this.handleRippleFocus();
     if (this._selectionController !== undefined) {
       this._selectionController.focus(this);
+    }
+  }
+
+  private _blurHandler() {
+    this.handleRippleBlur();
+    if (this._selectionController !== undefined) {
+      this._selectionController.blur(this);
     }
   }
 
@@ -201,7 +208,7 @@ export class RadioBase extends FormElement {
           @change="${this._changeHandler}"
           @click="${this._clickHandler}"
           @focus="${this._focusHandler}"
-          @blur="${this.handleRippleBlur}"
+          @blur="${this._blurHandler}"
           @mousedown="${this.handleRippleMouseDown}"
           @mouseenter="${this.handleRippleMouseEnter}"
           @mouseleave="${this.handleRippleMouseLeave}"

--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -16,13 +16,14 @@ limitations under the License.
 */
 import '@material/mwc-ripple/mwc-ripple';
 
-import {Ripple} from '@material/mwc-ripple/mwc-ripple';
-import {RippleHandlers} from '@material/mwc-ripple/ripple-handlers';
 import {addHasRemoveClass, FormElement} from '@material/mwc-base/form-element';
 import {observer} from '@material/mwc-base/observer';
+import {Ripple} from '@material/mwc-ripple/mwc-ripple';
+import {RippleHandlers} from '@material/mwc-ripple/ripple-handlers';
 import {MDCRadioAdapter} from '@material/radio/adapter';
 import MDCRadioFoundation from '@material/radio/foundation';
-import {html, property, query, queryAsync, internalProperty, eventOptions} from 'lit-element';
+import {eventOptions, html, internalProperty, property, query, queryAsync} from 'lit-element';
+
 import {SingleSelectionController} from './single-selection-controller';
 
 /**
@@ -258,5 +259,4 @@ export class RadioBase extends FormElement {
   private handleRippleBlur() {
     this.rippleHandlers.endFocus();
   }
-
 }

--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -165,8 +165,12 @@ export class RadioBase extends FormElement {
 
   protected renderRipple() {
     if (this.shouldRenderRipple) {
-      return html`<mwc-ripple .accent="${this.checked}" .disabled="${
-          this.disabled}" unbounded></mwc-ripple>`;
+      return html`
+        <mwc-ripple 
+          .accent="${this.checked}" 
+          .disabled="${this.disabled}" 
+          unbounded>
+        </mwc-ripple>`;
     }
     return html``;
   }

--- a/packages/radio/src/mwc-radio.scss
+++ b/packages/radio/src/mwc-radio.scss
@@ -16,10 +16,8 @@ limitations under the License.
 */
 
 @use '@material/radio';
-@use '@material/ripple';
 
-@include radio.core-styles();
-@include ripple.common();
+@include radio.without-ripple();
 
 :host {
   display: inline-block;

--- a/packages/radio/src/mwc-radio.scss
+++ b/packages/radio/src/mwc-radio.scss
@@ -25,6 +25,11 @@ limitations under the License.
 }
 
 .mdc-radio {
+  /* disable non-upgraded ripple on radio background */
+  .mdc-radio__background::before {
+    content: none;
+  }
+
   vertical-align: bottom;
   @include radio.unchecked-stroke-color(var(--mdc-radio-unchecked-color, #{radio.$unchecked-color}));
   @include radio.disabled-unchecked-stroke-color(var(--mdc-radio-disabled-color, #{radio.$disabled-circle-color}));

--- a/packages/radio/src/single-selection-controller.ts
+++ b/packages/radio/src/single-selection-controller.ts
@@ -227,7 +227,8 @@ export class SingleSelectionController {
   }
 
   /**
-   * Remove focused set when no element of the set has focus anymore, or if overridden by mouse
+   * Remove focused set when no element of the set has focus anymore, or if
+   * overridden by mouse
    *
    * @param element Element from which selection set is derived and subsequently
    *     blurred.

--- a/packages/radio/src/single-selection-controller.ts
+++ b/packages/radio/src/single-selection-controller.ts
@@ -94,8 +94,6 @@ export type CheckableElement = HTMLElement&{
 export class SingleSelectionController {
   private readonly sets: {[name: string]: SingleSelectionSet} = {};
 
-  private focusedSet: SingleSelectionSet|null = null;
-
   private mouseIsDown = false;
 
   private updating = false;
@@ -213,15 +211,14 @@ export class SingleSelectionController {
    * @param element Element from which selection set is derived and subsequently
    *     focused.
    */
-  focus(element: CheckableElement) {
+  async focus(element: CheckableElement) {
     // Only manage focus state when using keyboard
     if (this.mouseIsDown) {
       return;
     }
     const set = this.getSet(element.name);
-    const currentFocusedSet = this.focusedSet;
-    this.focusedSet = set;
-    if (currentFocusedSet != set && set.selected && set.selected != element) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (set.selected && set.selected != element) {
       set.selected.focus();
     }
   }


### PR DESCRIPTION
Refactor radio replace ripple with lazy mwc-ripple

And fix a bug where if you would focus a radio group for the second time while not focussing other radio groups it would not set focus on the selected element