### PR TITLE
fix: undeclared indirect dependencies

### DIFF
--- a/packages/circular-progress-four-color/package.json
+++ b/packages/circular-progress-four-color/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@material/circular-progress": "=8.0.0-canary.ac405eae1.0",
     "@material/mwc-base": "^0.17.2",
+    "@material/mwc-circular-progress": "*",
     "@material/theme": "=8.0.0-canary.ac405eae1.0",
     "lit-element": "^2.3.0",
     "tslib": "^1.10.0"

--- a/packages/circular-progress-four-color/package.json
+++ b/packages/circular-progress-four-color/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@material/circular-progress": "=8.0.0-canary.74839da7b.0",
     "@material/mwc-base": "^0.17.2",
-    "@material/mwc-circular-progress": "=8.0.0-canary.74839da7b.0",
+    "@material/mwc-circular-progress": "^0.17.2",
     "@material/theme": "=8.0.0-canary.74839da7b.0",
     "lit-element": "^2.3.0",
     "tslib": "^1.10.0"

--- a/packages/circular-progress/package.json
+++ b/packages/circular-progress/package.json
@@ -20,7 +20,7 @@
     "@material/mwc-base": "^0.17.2",
     "@material/theme": "=8.0.0-canary.74839da7b.0",
     "lit-element": "^2.3.0",
-    "lit-html": "*",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/circular-progress/package.json
+++ b/packages/circular-progress/package.json
@@ -20,6 +20,7 @@
     "@material/mwc-base": "^0.17.2",
     "@material/theme": "=8.0.0-canary.f86f83f54.0",
     "lit-element": "^2.3.0",
+    "lit-html": "*",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -19,7 +19,7 @@
     "@material/dialog": "=8.0.0-canary.74839da7b.0",
     "@material/dom": "=8.0.0-canary.74839da7b.0",
     "@material/mwc-base": "^0.17.2",
-    "@material/mwc-button": "*",
+    "@material/mwc-button": "^0.17.2",
     "blocking-elements": "^0.1.0",
     "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -19,6 +19,7 @@
     "@material/dialog": "=8.0.0-canary.f86f83f54.0",
     "@material/dom": "=8.0.0-canary.f86f83f54.0",
     "@material/mwc-base": "^0.17.2",
+    "@material/mwc-button": "*",
     "blocking-elements": "^0.1.0",
     "lit-element": "^2.3.0",
     "lit-html": "^1.1.2",

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -23,6 +23,9 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
+    "@material/mwc-checkbox": "*",
+    "@material/mwc-radio": "*",
+    "@material/mwc-switch": "*",
     "@material/rtl": "=8.0.0-canary.f86f83f54.0",
     "@material/theme": "=8.0.0-canary.f86f83f54.0",
     "@material/typography": "=8.0.0-canary.f86f83f54.0"

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -23,9 +23,9 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@material/mwc-checkbox": "=8.0.0-canary.74839da7b.0",
-    "@material/mwc-radio": "=8.0.0-canary.74839da7b.0",
-    "@material/mwc-switch": "=8.0.0-canary.74839da7b.0",
+    "@material/mwc-checkbox": "^0.17.2",
+    "@material/mwc-radio": "^0.17.2",
+    "@material/mwc-switch": "^0.17.2",
     "@material/rtl": "=8.0.0-canary.74839da7b.0",
     "@material/theme": "=8.0.0-canary.74839da7b.0",
     "@material/typography": "=8.0.0-canary.74839da7b.0"

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -20,7 +20,7 @@
     "@material/mwc-base": "^0.17.2",
     "@material/theme": "=8.0.0-canary.74839da7b.0",
     "lit-element": "^2.3.0",
-    "lit-html": "*",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -20,6 +20,7 @@
     "@material/mwc-base": "^0.17.2",
     "@material/theme": "=8.0.0-canary.f86f83f54.0",
     "lit-element": "^2.3.0",
+    "lit-html": "*",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -12,6 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/base": "=8.0.0-canary.f86f83f54.0",
+    "@material/dom": "*",
     "@material/list": "=8.0.0-canary.f86f83f54.0",
     "@material/mwc-base": "^0.17.2",
     "@material/mwc-checkbox": "^0.17.2",
@@ -24,6 +25,8 @@
   "devDependencies": {
     "@material/density": "=8.0.0-canary.f86f83f54.0",
     "@material/feature-targeting": "=8.0.0-canary.f86f83f54.0",
+    "@material/mwc-icon": "*",
+    "@material/mwc-menu": "*",
     "@material/ripple": "=8.0.0-canary.f86f83f54.0",
     "@material/rtl": "=8.0.0-canary.f86f83f54.0",
     "@material/theme": "=8.0.0-canary.f86f83f54.0",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -25,8 +25,8 @@
   "devDependencies": {
     "@material/density": "=8.0.0-canary.74839da7b.0",
     "@material/feature-targeting": "=8.0.0-canary.74839da7b.0",
-    "@material/mwc-icon": "=8.0.0-canary.74839da7b.0",
-    "@material/mwc-menu": "=8.0.0-canary.74839da7b.0",
+    "@material/mwc-icon": "^0.17.2",
+    "@material/mwc-menu": "^0.17.2",
     "@material/ripple": "=8.0.0-canary.74839da7b.0",
     "@material/rtl": "=8.0.0-canary.74839da7b.0",
     "@material/theme": "=8.0.0-canary.74839da7b.0",

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -19,6 +19,7 @@
     "@material/mwc-base": "^0.17.2",
     "@material/notched-outline": "=8.0.0-canary.f86f83f54.0",
     "lit-element": "^2.3.0",
+    "lit-html": "*",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -19,7 +19,7 @@
     "@material/mwc-base": "^0.17.2",
     "@material/notched-outline": "=8.0.0-canary.74839da7b.0",
     "lit-element": "^2.3.0",
-    "lit-html": "*",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@material/ripple": "=8.0.0-canary.74839da7b.0",
-    "lit-html": "^0.17.2"
+    "lit-html": "^1.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -23,7 +23,8 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@material/ripple": "=8.0.0-canary.f86f83f54.0"
+    "@material/ripple": "=8.0.0-canary.f86f83f54.0",
+    "lit-html": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -19,6 +19,7 @@
     "@material/dom": "=8.0.0-canary.f86f83f54.0",
     "@material/floating-label": "=8.0.0-canary.f86f83f54.0",
     "@material/line-ripple": "=8.0.0-canary.f86f83f54.0",
+    "@material/list": "*",
     "@material/mwc-base": "^0.17.2",
     "@material/mwc-floating-label": "^0.17.2",
     "@material/mwc-icon": "^0.17.2",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@material/ripple": "=8.0.0-canary.74839da7b.0",
-    "lit-html": "^0.17.2"
+    "lit-html": "^1.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -23,7 +23,8 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@material/ripple": "=8.0.0-canary.f86f83f54.0"
+    "@material/ripple": "=8.0.0-canary.f86f83f54.0",
+    "lit-html": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -25,7 +25,7 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-     "lit-html": "*"
+     "lit-html": "^1.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -24,6 +24,9 @@
     "lit-element": "^2.3.0",
     "tslib": "^1.10.0"
   },
+  "devDependencies": {
+     "lit-html": "*"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Ensures that all modules that are consumed are also listed as dependencies in the manifest.

See: https://github.com/yarnpkg/berry/tree/master/packages/yarnpkg-doctor#no-unlisted-dependencies

Neglecting to declare these dependencies can (and already does) lead to them being unavailable in some module resolution mechanisms.

This issue manifests in errors such as:
```
../.yarn/cache/@material-mwc-select-npm-0.17.2-d80ce2ad81-36d9783eac.zip/node_modules/@material/mwc-select/mwc-select-base.d.ts:22:28 - error TS2307: Cannot find module '@material/list/typeahead.js' or its corresponding type declarations.
22 import * as typeahead from '@material/list/typeahead.js';
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../.yarn/cache/@material-mwc-select-npm-0.17.2-d80ce2ad81-36d9783eac.zip/node_modules/@material/mwc-select/mwc-select-base.d.ts:23:37 - error TS2307: Cannot find module '@material/list/types' or its corresponding type declarations.
23 import { MDCListTextAndIndex } from '@material/list/types';
```