### PR TITLE
remove Fake in place of module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7584,6 +7584,12 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "hanbi": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hanbi/-/hanbi-0.4.0.tgz",
+      "integrity": "sha512-2FR1EGl+xwhB1IGpqZzktpypbJOuwUuSpUY+2ibQK4xmh/pNb/4Liwf+Vx7CAMEVrWEgIruA4V09qxVN/yhrHQ==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.6",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-wc": "^1.2.0",
     "glob": "^7.1.1",
+    "hanbi": "^0.4.0",
     "html-minifier-terser": "^5.1.0",
     "karma": "^4.0.1",
     "karma-chai": "^0.1.0",
@@ -94,6 +95,5 @@
     "shady-css-parser": "^0.1.0",
     "tachometer": "^0.4.13",
     "typescript": "^3.4.1"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/checkbox/test/mwc-checkbox.test.ts
+++ b/packages/checkbox/test/mwc-checkbox.test.ts
@@ -16,9 +16,10 @@
  */
 
 import {Checkbox} from '@material/mwc-checkbox';
+import * as hanbi from 'hanbi';
 import {html} from 'lit-html';
 
-import {Fake, fixture, rafPromise, TestFixture} from '../../../test/src/util/helpers';
+import {fixture, rafPromise, TestFixture} from '../../../test/src/util/helpers';
 
 interface CheckboxInternals {
   formElement: HTMLInputElement;
@@ -79,7 +80,7 @@ suite('mwc-checkbox', () => {
         });
 
     test('user input emits `change` event', async () => {
-      const callback = new Fake<[], void>();
+      const callback = hanbi.spy();
       element.addEventListener('change', callback.handler);
       element.click();
       assert.equal(callback.callCount, 1);

--- a/packages/menu/test/mwc-menu.test.ts
+++ b/packages/menu/test/mwc-menu.test.ts
@@ -22,9 +22,10 @@ import {List} from '@material/mwc-list';
 import {ListItem} from '@material/mwc-list/mwc-list-item';
 import {Menu} from '@material/mwc-menu';
 import {Corner, MenuCorner, MenuSurface} from '@material/mwc-menu/mwc-menu-surface';
+import * as hanbi from 'hanbi';
 import {html, TemplateResult} from 'lit-html';
 
-import {Fake, fixture, ieSafeKeyboardEvent, rafPromise, TestFixture} from '../../../test/src/util/helpers';
+import {fixture, ieSafeKeyboardEvent, rafPromise, TestFixture} from '../../../test/src/util/helpers';
 
 const defaultMenu = html`<mwc-menu></mwc-menu>`;
 const defaultSurface = html`<mwc-menu-surface></mwc-menu-surface>`;
@@ -489,7 +490,7 @@ suite('mwc-menu-surface', () => {
     });
 
     test('closing fires the closed event', async () => {
-      const fake = new Fake<[], void>();
+      const fake = hanbi.spy();
       element.addEventListener('closed', fake.handler);
       element.show();
       await element.updateComplete;
@@ -501,7 +502,7 @@ suite('mwc-menu-surface', () => {
     });
 
     test('opening fires the opened event', async () => {
-      const fake = new Fake<[], void>();
+      const fake = hanbi.spy();
       element.addEventListener('opened', fake.handler);
       element.show();
       await element.updateComplete;

--- a/packages/slider/test/mwc-slider.test.ts
+++ b/packages/slider/test/mwc-slider.test.ts
@@ -16,9 +16,10 @@
  */
 
 import {Slider} from '@material/mwc-slider/mwc-slider';
+import * as hanbi from 'hanbi';
 import {html} from 'lit-html';
 
-import {Fake, fixture, ieSafeKeyboardEvent, rafPromise, TestFixture} from '../../../test/src/util/helpers';
+import {fixture, ieSafeKeyboardEvent, rafPromise, TestFixture} from '../../../test/src/util/helpers';
 
 const defaultSliderProps = {
   min: 0,
@@ -88,8 +89,8 @@ suite('mwc-slider', () => {
 
     test('key events change value and fire events', async () => {
       const slider = element.shadowRoot!.querySelector('.mdc-slider')!;
-      const inputHandler = new Fake<[], void>();
-      const changeHandler = new Fake<[], void>();
+      const inputHandler = hanbi.spy();
+      const changeHandler = hanbi.spy();
       element.addEventListener('input', inputHandler.handler);
       element.addEventListener('change', changeHandler.handler);
 

--- a/packages/snackbar/test/mwc-snackbar.test.ts
+++ b/packages/snackbar/test/mwc-snackbar.test.ts
@@ -16,9 +16,10 @@
  */
 
 import {Snackbar} from '@material/mwc-snackbar';
+import * as hanbi from 'hanbi';
 import {html, TemplateResult} from 'lit-html';
 
-import {Fake, fixture, ieSafeKeyboardEvent, rafPromise, TestFixture} from '../../../test/src/util/helpers';
+import {fixture, ieSafeKeyboardEvent, rafPromise, TestFixture} from '../../../test/src/util/helpers';
 
 interface SnackBarProps {
   timeoutMs: number;
@@ -94,8 +95,8 @@ suite('mwc-snackbar', () => {
     });
 
     test('`show()` opens snack bar', async () => {
-      const openedHandler = new Fake<[], void>();
-      const openingHandler = new Fake<[], void>();
+      const openedHandler = hanbi.spy();
+      const openingHandler = hanbi.spy();
       element.addEventListener('MDCSnackbar:opened', openedHandler.handler);
       element.addEventListener('MDCSnackbar:opening', openingHandler.handler);
       assert.equal(element.open, false);
@@ -108,8 +109,8 @@ suite('mwc-snackbar', () => {
     });
 
     test('`open = true` opens snack bar', async () => {
-      const openedHandler = new Fake<[], void>();
-      const openingHandler = new Fake<[], void>();
+      const openedHandler = hanbi.spy();
+      const openingHandler = hanbi.spy();
       element.addEventListener('MDCSnackbar:opened', openedHandler.handler);
       element.addEventListener('MDCSnackbar:opening', openingHandler.handler);
       assert.equal(element.open, false);
@@ -123,7 +124,7 @@ suite('mwc-snackbar', () => {
     });
 
     test('`close()` closes snack bar', async () => {
-      const closedHandler = new Fake<[], void>();
+      const closedHandler = hanbi.spy();
       element.addEventListener('MDCSnackbar:closed', closedHandler.handler);
       element.show();
       await element.updateComplete;
@@ -135,7 +136,7 @@ suite('mwc-snackbar', () => {
     });
 
     test('`open = false` closes snack bar', async () => {
-      const closedHandler = new Fake<[], void>();
+      const closedHandler = hanbi.spy();
       element.addEventListener('MDCSnackbar:closed', closedHandler.handler);
       element.show();
       await element.updateComplete;
@@ -179,13 +180,13 @@ suite('mwc-snackbar', () => {
 
     test('closes when dismissed', async () => {
       const close = element.querySelector<HTMLElement>('[slot="dismiss"]')!;
-      const closedHandler = new Fake<[Event], void>();
+      const closedHandler = hanbi.spy();
       element.addEventListener('MDCSnackbar:closed', closedHandler.handler);
       element.show();
       await element.updateComplete;
       close.click();
       assert.isFalse(element.open);
-      const ev = closedHandler.calls[0].args[0] as CustomEvent;
+      const ev = closedHandler.getCall(0).args[0] as CustomEvent;
       assert.equal(ev.detail.reason, 'dismiss');
     });
   });
@@ -200,13 +201,13 @@ suite('mwc-snackbar', () => {
 
     test('closes when actioned', async () => {
       const action = element.querySelector<HTMLElement>('[slot="action"]')!;
-      const closedHandler = new Fake<[Event], void>();
+      const closedHandler = hanbi.spy();
       element.addEventListener('MDCSnackbar:closed', closedHandler.handler);
       element.show();
       await element.updateComplete;
       action.click();
       assert.isFalse(element.open);
-      const ev = closedHandler.calls[0].args[0] as CustomEvent;
+      const ev = closedHandler.getCall(0).args[0] as CustomEvent;
       assert.equal(ev.detail.reason, 'action');
     });
   });

--- a/packages/switch/test/mwc-switch.test.ts
+++ b/packages/switch/test/mwc-switch.test.ts
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 import {Switch} from '@material/mwc-switch';
+import * as hanbi from 'hanbi';
 import {html} from 'lit-html';
 
-import {Fake, fixture, TestFixture} from '../../../test/src/util/helpers';
+import {fixture, TestFixture} from '../../../test/src/util/helpers';
 
 interface SwitchProps {
   checked: boolean;
@@ -56,7 +57,7 @@ suite('mwc-switch', () => {
     });
 
     test('user input emits `change` event', async () => {
-      const callback = new Fake<[], void>();
+      const callback = hanbi.spy();
       element.addEventListener('change', callback.handler);
 
       element.click();

--- a/packages/tab/test/mwc-tab.test.ts
+++ b/packages/tab/test/mwc-tab.test.ts
@@ -16,9 +16,10 @@
  */
 
 import {Tab} from '@material/mwc-tab';
+import * as hanbi from 'hanbi';
 import {html} from 'lit-html';
 
-import {Fake, fixture, rafPromise, TestFixture} from '../../../test/src/util/helpers';
+import {fixture, rafPromise, TestFixture} from '../../../test/src/util/helpers';
 
 interface TabProps {
   label: string;
@@ -69,7 +70,7 @@ suite('mwc-tab', () => {
     });
 
     test('fires interacted event on click', () => {
-      const interactedHandler = new Fake<[], void>();
+      const interactedHandler = hanbi.spy();
       element.addEventListener('MDCTab:interacted', interactedHandler.handler);
       const tab = element.shadowRoot!.querySelector<HTMLElement>('.mdc-tab')!;
       tab.click();

--- a/test/src/util/helpers.ts
+++ b/test/src/util/helpers.ts
@@ -178,25 +178,6 @@ export const rafPromise = async () => new Promise((res) => {
   requestAnimationFrame(res);
 });
 
-export class Fake<TArgs extends any[], TReturn> {
-  public calls: Array<{args: TArgs}> = [];
-  public get called(): boolean {
-    return this.calls.length > 0;
-  }
-  public get callCount(): number {
-    return this.calls.length;
-  }
-  public returnValue?: TReturn;
-  public handler: (...args: TArgs) => TReturn;
-
-  public constructor() {
-    this.handler = (...args: TArgs) => {
-      this.calls.push({args});
-      return this.returnValue as TReturn;
-    };
-  }
-}
-
 export const waitForEvent = (el: Element, ev: string) => new Promise((res) => {
   el.addEventListener(ev, () => {
     res();


### PR DESCRIPTION
a while ago i removed sinon and left over some of our own helpers to deal with that.

this just removes the `Fake` i added and uses a dependency instead so we have less to maintain. timers are still mocked by ourselves though.

if you prefer having your own implementation, thats fair enough just let me know. 

have left the PR as draft for now just in case CI has different test results than i had locally.