### PR TITLE
Fix typo in circular-progress-four-color component README.md.

### DIFF
--- a/packages/circular-progress-four-color/README.md
+++ b/packages/circular-progress-four-color/README.md
@@ -40,7 +40,7 @@ four colors by default. These colors may be specified as follows:
 
 ```html
 <style>
-  mwc-circular-progress {
+  mwc-circular-progress-four-color {
     --mdc-circular-progress-bar-color-1: #2196f3;
     --mdc-circular-progress-bar-color-2: #e91e63;
     --mdc-circular-progress-bar-color-3: #ffc107;


### PR DESCRIPTION
Fix typo in circular-progress-four-color component README.md.