### PR TITLE
chore: bump safari test versions & fix test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -104,24 +104,18 @@ module.exports = function(config) {
         version: '11',
         platform: 'Windows 8.1',
       },
-      'sl-safari-11': {
+      'sl-safari-14': {
         base: 'SauceLabs',
         browserName: 'safari',
-        version: '11',
-        platform: 'macOS 10.13',
+        version: '14',
+        platform: 'macOS 11.00',
       },
-      'sl-safari-10': {
+      'sl-safari-13': {
         base: 'SauceLabs',
         browserName: 'safari',
-        version: '10',
-        platform: 'OS X 10.12',
+        version: '13',
+        platform: 'OS X 10.15',
       },
-      // 'sl-safari-9': {
-      //   base: 'SauceLabs',
-      //   browserName: 'safari',
-      //   version: '9',
-      //   platform: 'OS X 10.11',
-      // },
       // 'sl-chrome-41': {
       //   base: 'SauceLabs',
       //   browserName: 'chrome',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -114,7 +114,7 @@ module.exports = function(config) {
         base: 'SauceLabs',
         browserName: 'safari',
         version: '13',
-        platform: 'OS X 10.15',
+        platform: 'macOS 10.15',
       },
       // 'sl-chrome-41': {
       //   base: 'SauceLabs',

--- a/packages/drawer/test/mwc-drawer.test.ts
+++ b/packages/drawer/test/mwc-drawer.test.ts
@@ -40,6 +40,20 @@ const drawer = (propsInit: Partial<DrawerProps>) => {
   `;
 };
 
+const IS_SAFARI_13 =
+    window.navigator.appVersion?.indexOf('AppleWebKit') !== -1 &&
+    window.navigator.appVersion?.indexOf('Version/13.1') !== -1;
+
+const transitionend = async (drawer: Element) => {
+  if (IS_SAFARI_13) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 400);
+    });
+  } else {
+    await waitForEvent(drawer, 'transitionend');
+  }
+};
+
 suite('mwc-drawer', () => {
   let fixt: TestFixture;
   let element: Drawer;
@@ -73,10 +87,11 @@ suite('mwc-drawer', () => {
       });
       element.type = 'dismissible';
       element.open = true;
-      await waitForEvent(drawer, 'transitionend');
+      await transitionend(drawer);
       assert.equal(openedFired, true);
       element.open = false;
-      await waitForEvent(drawer, 'transitionend');
+      await transitionend(drawer);
+
       assert.equal(closedFired, true);
     });
   });
@@ -117,9 +132,11 @@ suite('mwc-drawer', () => {
       const scrim =
           element.shadowRoot!.querySelector<HTMLElement>(SCRIM_SELECTOR)!;
       element.open = true;
-      await waitForEvent(drawer, 'transitionend');
+      await transitionend(drawer);
+
       scrim.click();
-      await waitForEvent(drawer, 'transitionend');
+      await transitionend(drawer);
+
       assert.equal(element.open, false);
     });
   });


### PR DESCRIPTION
Bumped safari versions, for some reason transitionend does not fire on safari 13 twice in a row. Behavior seems correct, but the browser is just not firing the event. Safari 13-specific workaround implemented

fixes #1869