### PR TITLE
Allows setting a custom menu corner property to the select element

### DIFF
--- a/packages/select/mwc-select-base.ts
+++ b/packages/select/mwc-select-base.ts
@@ -30,6 +30,7 @@ import {floatingLabel, FloatingLabel} from '@material/mwc-floating-label';
 import {lineRipple, LineRipple} from '@material/mwc-line-ripple';
 import {ListItemBase} from '@material/mwc-list/mwc-list-item-base';
 import {Menu} from '@material/mwc-menu';
+import {Corner} from '@material/mwc-menu/mwc-menu-surface-base';
 import {NotchedOutline} from '@material/mwc-notched-outline';
 import {MDCSelectAdapter} from '@material/select/adapter';
 import MDCSelectFoundation from '@material/select/foundation';
@@ -37,7 +38,6 @@ import {eventOptions, html, internalProperty, property, query} from 'lit-element
 import {nothing} from 'lit-html';
 import {classMap} from 'lit-html/directives/class-map';
 import {ifDefined} from 'lit-html/directives/if-defined';
-import {Corner} from '@material/mwc-menu/mwc-menu-surface-base';
 
 // must be done to get past lit-analyzer checks
 declare global {

--- a/packages/select/mwc-select-base.ts
+++ b/packages/select/mwc-select-base.ts
@@ -185,6 +185,8 @@ export abstract class SelectBase extends FormElement {
 
   @property({type: Boolean}) fixedMenuPosition = false;
 
+  @property({type: String}) menuCorner = 'BOTTOM_START';
+
   // Transiently holds current typeahead prefix from user.
   protected typeaheadState = typeahead.initState();
   protected sortedIndexByFirstChar = new Map<string, MDCListTextAndIndex[]>();
@@ -325,6 +327,7 @@ export abstract class SelectBase extends FormElement {
             .open=${this.menuOpen}
             .anchor=${this.anchorElement}
             .fixed=${this.fixedMenuPosition}
+            .corner=${this.menuCorner}
             @selected=${this.onSelected}
             @opened=${this.onOpened}
             @closed=${this.onClosed}

--- a/packages/select/mwc-select-base.ts
+++ b/packages/select/mwc-select-base.ts
@@ -37,6 +37,7 @@ import {eventOptions, html, internalProperty, property, query} from 'lit-element
 import {nothing} from 'lit-html';
 import {classMap} from 'lit-html/directives/class-map';
 import {ifDefined} from 'lit-html/directives/if-defined';
+import {Corner} from '@material/mwc-menu/mwc-menu-surface-base';
 
 // must be done to get past lit-analyzer checks
 declare global {
@@ -185,7 +186,7 @@ export abstract class SelectBase extends FormElement {
 
   @property({type: Boolean}) fixedMenuPosition = false;
 
-  @property({type: String}) menuCorner = 'BOTTOM_START';
+  @property({type: String}) menuCorner: Corner = 'BOTTOM_START';
 
   // Transiently holds current typeahead prefix from user.
   protected typeaheadState = typeahead.initState();

--- a/packages/select/mwc-select-base.ts
+++ b/packages/select/mwc-select-base.ts
@@ -523,10 +523,10 @@ export abstract class SelectBase extends FormElement {
       setMenuAnchorElement: () => {
         /* Handled by anchor directive */
       },
-      setMenuAnchorCorner: () => {
+      setMenuAnchorCorner: (corner = 'BOTTOM_START') => {
         const menuElement = this.menuElement;
         if (menuElement) {
-          menuElement.corner = 'BOTTOM_START';
+          menuElement.corner = corner;
         }
       },
       setMenuWrapFocus: (wrapFocus) => {

--- a/packages/select/mwc-select-base.ts
+++ b/packages/select/mwc-select-base.ts
@@ -527,10 +527,10 @@ export abstract class SelectBase extends FormElement {
       setMenuAnchorElement: () => {
         /* Handled by anchor directive */
       },
-      setMenuAnchorCorner: (corner = 'BOTTOM_START') => {
+      setMenuAnchorCorner: () => {
         const menuElement = this.menuElement;
         if (menuElement) {
-          menuElement.corner = corner;
+          menuElement.corner = 'BOTTOM_START';
         }
       },
       setMenuWrapFocus: (wrapFocus) => {


### PR DESCRIPTION
Adds a `menuCorner` property to the select element for setting the internal menu corner property to a custom value, different from the current `BOTTOM_START`.