### PR TITLE
New sass compile pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 /packages/**/*.d.ts
 /packages/*/*.tgz
 /packages/*/*-css.ts
+/packages/*/*.css.ts
 /packages/*/package-lock.json
 **/*.tsbuildinfo*
 !packages/*/custom_types/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+- all
+  - Update sass build to match internal imports and naming
+
+### Fixed
+
+### Added
 
 ## [v0.21.0] - 2021-04-30
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postinstall": "npm run bootstrap",
     "bootstrap": "./scripts/bootstrap.sh",
     "build": "npm run build:styling && npm run build:typescript -- --verbose",
-    "build:styling": "./scripts/build-styling.sh",
+    "build:styling": "./scripts/build-styling.sh && lerna run --stream build:style",
     "build:typescript": "tsc --build",
     "build:tests": "tsc --build test/tsconfig.json && tsc --build test/tsconfig-node.json",
     "build:scripts": "tsc --project scripts/tsconfig.json",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -22,6 +22,9 @@
     "lit-html": "^1.4.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js styles.scss demo_styles.scss"
+  },
   "devDependencies": {
     "@material/button": "=12.0.0-canary.1a8d06483.0",
     "@material/elevation": "=12.0.0-canary.1a8d06483.0",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -22,6 +22,9 @@
     "lit-html": "^1.4.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-checkbox.scss"
+  },
   "devDependencies": {
     "@material/checkbox": "=12.0.0-canary.1a8d06483.0",
     "@material/theme": "=12.0.0-canary.1a8d06483.0",

--- a/packages/circular-progress-four-color/package.json
+++ b/packages/circular-progress-four-color/package.json
@@ -23,6 +23,9 @@
     "lit-element": "^2.5.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-circular-progress-four-color.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/circular-progress/package.json
+++ b/packages/circular-progress/package.json
@@ -23,6 +23,9 @@
     "lit-html": "^1.4.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-circular-progress.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -26,6 +26,9 @@
     "tslib": "^2.0.1",
     "wicg-inert": "^3.0.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-dialog.scss"
+  },
   "devDependencies": {
     "@material/elevation": "=12.0.0-canary.1a8d06483.0",
     "@material/feature-targeting": "=12.0.0-canary.1a8d06483.0",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -24,6 +24,9 @@
     "tslib": "^2.0.1",
     "wicg-inert": "^3.0.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-drawer.scss"
+  },
   "devDependencies": {
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },

--- a/packages/elevation-overlay/package.json
+++ b/packages/elevation-overlay/package.json
@@ -24,6 +24,9 @@
     "@material/elevation": "=12.0.0-canary.1a8d06483.0",
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-elevation-overlay.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -32,6 +32,9 @@
     "@material/shape": "=12.0.0-canary.1a8d06483.0",
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-fab.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -27,6 +27,9 @@
     "@material/rtl": "=12.0.0-canary.1a8d06483.0",
     "@material/typography": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-floating-label.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -30,6 +30,9 @@
     "@material/theme": "=12.0.0-canary.1a8d06483.0",
     "@material/typography": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-formfield.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -20,6 +20,9 @@
     "lit-element": "^2.5.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-icon-button.scss"
+  },
   "devDependencies": {
     "@material/feature-targeting": "=12.0.0-canary.1a8d06483.0",
     "@material/icon-button": "=12.0.0-canary.1a8d06483.0",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -19,6 +19,9 @@
     "lit-element": "^2.5.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-icon-host.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -21,6 +21,9 @@
     "lit-html": "^1.4.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-line-ripple.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -22,6 +22,9 @@
     "lit-html": "^1.4.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-linear-progress.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -32,6 +32,9 @@
     "@material/theme": "=12.0.0-canary.1a8d06483.0",
     "@material/typography": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-list.scss mwc-list-item.scss mwc-control-list-item.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -24,6 +24,9 @@
   "devDependencies": {
     "@material/shape": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-menu.scss mwc-menu-surface.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -27,6 +27,9 @@
     "@material/shape": "=12.0.0-canary.1a8d06483.0",
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-notched-outline.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -26,6 +26,9 @@
     "@material/ripple": "=12.0.0-canary.1a8d06483.0",
     "lit-html": "^1.4.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-radio.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -26,6 +26,9 @@
   "devDependencies": {
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-ripple.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -35,6 +35,9 @@
   "devDependencies": {
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-select.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -23,6 +23,9 @@
     "lit-html": "^1.4.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-slider.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -26,6 +26,9 @@
     "@material/feature-targeting": "=12.0.0-canary.1a8d06483.0",
     "@material/rtl": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-snackbar.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -26,6 +26,9 @@
     "@material/ripple": "=12.0.0-canary.1a8d06483.0",
     "lit-html": "^1.4.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-switch.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -27,6 +27,9 @@
   "devDependencies": {
     "lit-html": "^1.4.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-tab-bar.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -25,6 +25,9 @@
   "devDependencies": {
     "@material/mwc-icon": "^0.21.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-tab-indicator.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -22,6 +22,9 @@
     "lit-element": "^2.5.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-tab-scroller.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -29,6 +29,9 @@
     "@material/ripple": "=12.0.0-canary.1a8d06483.0",
     "@material/rtl": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-tab.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -22,6 +22,9 @@
     "lit-html": "^1.4.0",
     "tslib": "^2.0.1"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-textarea.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -34,6 +34,9 @@
     "@material/shape": "=12.0.0-canary.1a8d06483.0",
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-textfield.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -27,6 +27,9 @@
     "@material/elevation": "=12.0.0-canary.1a8d06483.0",
     "@material/theme": "=12.0.0-canary.1a8d06483.0"
   },
+  "scripts": {
+    "build:style": "node ../../scripts/sass-to-lit-css/index.js mwc-top-app-bar.scss"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/scripts/sass-to-lit-css/index.js
+++ b/scripts/sass-to-lit-css/index.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+@license
+Copyright 2021 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const path = require('path');
+const commandLineArgs = require('command-line-args');
+const sassRender = require('../sass-render/index.js').sassRender;
+
+const options = [
+  {
+    name: 'source',
+    alias: 's',
+    type: String,
+    multiple: true,
+    defaultOption: true,
+  },
+];
+
+const {source} = commandLineArgs(options);
+
+if (!source) {
+  console.error('Must provide a source file!');
+  process.exit(-1);
+}
+
+const template = path.resolve(process.argv[1], '../template.tmpl');
+
+for (const sourceFile of source) {
+  const output = sourceFile.replace(/\.scss$/, '.css.ts');
+  sassRender(sourceFile, template, output).catch((err) => {
+    console.error(err);
+    process.exit(-1);
+  });
+}

--- a/scripts/sass-to-lit-css/template.tmpl
+++ b/scripts/sass-to-lit-css/template.tmpl
@@ -1,19 +1,7 @@
 /**
-@license
-Copyright 2021 Google Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-LIcense-Identifier: Apache-2.0
+ */
 import {css} from 'lit-element';
-
 export const styles = css`<% content %>`;

--- a/scripts/sass-to-lit-css/template.tmpl
+++ b/scripts/sass-to-lit-css/template.tmpl
@@ -1,0 +1,19 @@
+/**
+@license
+Copyright 2021 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import {css} from 'lit-element';
+
+export const styles = css`<% content %>`;


### PR DESCRIPTION
- Reuse `sass-render` internals, but structured so that each component
  can build independently
- Emit stylesheet as `styles` rather than `style` to match internal
  build
- Emit stylesheets as `.css.ts` instead of `-css.ts` to match internal
  build

Related #2348