### PR TITLE
feat(tab): Add min-width css variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `tab`
+  - Add `--mdc-tab-min-width` variable
+
 ## [v0.21.0] - 2021-04-30
 
 ### Changed

--- a/packages/tab/README.md
+++ b/packages/tab/README.md
@@ -72,6 +72,7 @@ Name                                 | Default                                  
 ------------------------------------ | -------------------------------------------------------- | -----------
 `--mdc-tab-height`                   | `48px`                                                   | Height of the tab.
 `--mdc-tab-horizontal-padding`       | `24px`                                                   | Horizontal padding on either side of the tab.
+`--mdc-tab-min-width`                | `90px`                                                   | Minimum width of the tab.
 `--mdc-tab-stacked-height`           | `72px`                                                   | Height of the tab's stacked variant.
 `--mdc-tab-text-label-color-default` | ![](images/color_0,0,0,60.png) `rgba(0, 0, 0, 0.6)`  | Color of an unactivated tab label.
 `--mdc-tab-color-default`            | ![](images/color_0,0,0,54.png) `rgba(0, 0, 0, 0.54)` | Color of an unactivated icon.

--- a/packages/tab/mwc-tab.scss
+++ b/packages/tab/mwc-tab.scss
@@ -31,6 +31,9 @@
   @include tab.horizontal-padding(
     var(--mdc-tab-horizontal-padding, #{tab.$horizontal-padding})
   );
+  @include tab.min-width(
+    var(--mdc-tab-min-width, #{tab.$min-width})
+  );
 }
 
 .mdc-tab--stacked {


### PR DESCRIPTION
Allow to configure the default 90px min-width that has been added in
https://github.com/material-components/material-components-web/commit/c4ab98722