### PR TITLE
chore: Remove typescript lint from GitHub tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "clang-format --version; find . -name '*.ts' | grep -v node_modules | grep -v .d.ts | grep -v -- -css.ts | xargs clang-format -style=file -i",
     "format:check": "npm run format && git diff --exit-code || (echo '\\033[31mERROR:\\033[0m Project is not formatted. Please run \"npm run format\".' && false)",
     "lint:imports": "node scripts/check-imports.js",
-    "lint": "npm run lint:typescript && npm run lint:lit",
+    "lint": "npm run lint:lit",
     "lint:fix": "npm run lint:typescript -- --fix && npm run lint:lit -- --fix",
     "lint:typescript": "eslint \"packages/**/*.ts\"",
     "lint:lit": "lit-analyzer \"packages/**/*.ts\" --strict",


### PR DESCRIPTION
External typescript lint (including format lint) conflicts with internal TS lint and produces different results. This impedes devex because the turn around time to validate lint is slow (i.e., waits till GitHub Action is complete), also has no integration to internal review tool.

All the code that gets checked-in should be tested internally.