### PR TITLE
Update Sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13326,9 +13326,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.32.12",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.12.tgz",
-      "integrity": "sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.34.1.tgz",
+      "integrity": "sha512-scLA7EIZM+MmYlej6sdVr0HRbZX5caX5ofDT9asWnUJj21oqgsC+1LuNfm0eg+vM0fCTZHhwImTiCU0sx9h9CQ==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-minify-html-literals": "^1.2.3",
     "rollup-plugin-terser": "^5.3.0",
-    "sass": "^1.24.4",
+    "sass": "^1.34.1",
     "shady-css-parser": "^0.1.0",
     "tachometer": "^0.4.13",
     "typescript": "^4.1.4"


### PR DESCRIPTION
https://github.com/material-components/material-components-web/pull/7158 updated Sass and started using `math.div`, but this repo is currently using a slightly older version of Sass that doesn't support `math.div`, which breaks the build.