### PR TITLE
Restore newer version of Sass.

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-minify-html-literals": "^1.2.3",
     "rollup-plugin-terser": "^5.3.0",
-    "sass": "^1.24.4",
+    "sass": "^1.34.1",
     "shady-css-parser": "^0.1.0",
     "tachometer": "^0.4.13",
     "typescript": "^4.1.4"


### PR DESCRIPTION
The copybara bot reverted the new Sass version from #2475 in #2473, but only in `package.json`.