### PR TITLE
Add `mwc-base` dependency to linear progress

### DIFF
--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -16,6 +16,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@material/mwc-base": "^0.21.0",
     "@material/linear-progress": "=12.0.0-canary.8415ae585.0",
     "@material/theme": "=12.0.0-canary.8415ae585.0",
     "lit-element": "^2.5.0",


### PR DESCRIPTION
`mwc-base` is used in linear progress, but was missing from its dependencies.