### PR TITLE
chore: Remove lint checks from Github Action tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,7 @@ jobs:
       run: npm ci --ignore-scripts
       
     - name: Lerna bootstrap
-      run: npm run bootstrap
-      
-    - name: Check Lint
-      run: npm run lint
+      run: npm run bootstrap      
   tests:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Similar to MDC-Web removing any external lint checks which are redundant (and potentially out of sync) with internal lint checks.

Every change should be tested internally before commit.